### PR TITLE
Feature/#23 사이드 모달 구현

### DIFF
--- a/src/components/Mission/MissionItem.jsx
+++ b/src/components/Mission/MissionItem.jsx
@@ -10,6 +10,7 @@ function MissionItem({
   course,
   isDummy = false,
   currentState = null,
+  onClick = () => {},
 }) {
   const difficultyMap = {
     EASY: "쉬움",
@@ -34,7 +35,13 @@ function MissionItem({
     );
   } else {
     return (
-      <li className={[styles.missionItem, classByState ? styles[classByState] : ""].join(" ")}>
+      <li
+        className={[
+          styles.missionItem,
+          classByState ? styles[classByState] : "",
+        ].join(" ")}
+        onClick={onClick}
+      >
         <p>{title}</p>
         <div style={{ display: "none" }}>
           <progress value={progressValue} max={maxProgress} />

--- a/src/components/common/SideModal/SideModal.jsx
+++ b/src/components/common/SideModal/SideModal.jsx
@@ -26,7 +26,7 @@ function SideModal({ isOpen, onClose, width = 300, children }) {
           height: "100vh",
           width: `${width}px`,
           backgroundColor: "#fff",
-          boxShadow: "-2px 0 8px rgba(0, 0, 0, 0.3)",
+          boxShadow: isOpen ? "-2px 0 8px rgba(0, 0, 0, 0.3)" : "none",
           transform: isOpen ? "translateX(0)" : `translateX(${width}px)`,
           transition: "transform 0.3s ease-out",
           zIndex: 1000,

--- a/src/components/common/SideModal/SideModal.jsx
+++ b/src/components/common/SideModal/SideModal.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+
+function SideModal({ isOpen, onClose, width = 300, children }) {
+  return (
+    <>
+      <div
+        onClick={onClose}
+        style={{
+          position: "fixed",
+          top: 0,
+          left: 0,
+          width: "100vw",
+          height: "100vh",
+          backgroundColor: "rgba(0,0,0,0.3)",
+          opacity: isOpen ? 1 : 0,
+          pointerEvents: isOpen ? "auto" : "none",
+          transition: "opacity 0.3s",
+          zIndex: 999,
+        }}
+      />
+
+      {/* 모달 */}
+      <div
+        style={{
+          position: "fixed",
+          top: 0,
+          right: 0,
+          height: "100vh",
+          width: `${width}px`,
+          backgroundColor: "#fff",
+          boxShadow: "-2px 0 8px rgba(0, 0, 0, 0.3)",
+          transform: isOpen ? "translateX(0)" : `translateX(${width}px)`,
+          transition: "transform 0.3s ease-out",
+          zIndex: 1000,
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        {children}
+      </div>
+    </>
+  );
+}
+
+export default SideModal;

--- a/src/components/common/SideModal/SideModal.jsx
+++ b/src/components/common/SideModal/SideModal.jsx
@@ -11,15 +11,13 @@ function SideModal({ isOpen, onClose, width = 300, children }) {
           left: 0,
           width: "100vw",
           height: "100vh",
-          backgroundColor: "rgba(0,0,0,0.3)",
+          backgroundColor: "rgba(0,0,0,0.0)",
           opacity: isOpen ? 1 : 0,
           pointerEvents: isOpen ? "auto" : "none",
           transition: "opacity 0.3s",
           zIndex: 999,
         }}
       />
-
-      {/* 모달 */}
       <div
         style={{
           position: "fixed",

--- a/src/pages/mission/MissionOverviewPage.jsx
+++ b/src/pages/mission/MissionOverviewPage.jsx
@@ -3,6 +3,7 @@ import styles from "./MissionOverviewPage.module.scss";
 import MissionItem from "../../components/Mission/MissionItem";
 import { getMyMissionGroups, getMissions } from "../../api/missionService";
 import { myChallenges } from "../../api/missionService";
+import SideModal from "../../components/common/SideModal/SideModal";
 
 function MissionOverviewPage() {
   const [missionGroups, setMissionGroups] = useState([]);
@@ -11,6 +12,8 @@ function MissionOverviewPage() {
   const [missionRows, setMissionRows] = useState({});
   const [missionLevels, setMissionLevels] = useState([]);
   const [challenges, setChallenges] = useState({});
+  const [isSideModalOpen, setIsSideModalOpen] = useState(false);
+  const sideModalWidth = 400;
 
   useEffect(() => {
     const fetchMissionGroups = async () => {
@@ -141,6 +144,13 @@ function MissionOverviewPage() {
                           .progress
                       : null
                   }
+                  onClick={() => {
+                    setIsSideModalOpen(true);
+                    console.log(
+                      "미션 클릭:",
+                      missionRows[missionRow][missionCol]
+                    );
+                  }}
                 />
               ) : (
                 <MissionItem key={index} isDummy={true} />
@@ -149,6 +159,13 @@ function MissionOverviewPage() {
           </ul>
         ))}
       </div>
+      <SideModal
+        isOpen={isSideModalOpen}
+        onClose={() => setIsSideModalOpen(false)}
+        width={sideModalWidth}
+      >
+        <div className={styles.missionDetail}></div>
+      </SideModal>
     </div>
   );
 }

--- a/src/pages/mission/MissionOverviewPage.jsx
+++ b/src/pages/mission/MissionOverviewPage.jsx
@@ -146,10 +146,12 @@ function MissionOverviewPage() {
                   }
                   onClick={() => {
                     setIsSideModalOpen(true);
-                    console.log(
-                      "미션 클릭:",
-                      missionRows[missionRow][missionCol]
-                    );
+                    if (process.env.NODE_ENV === "development") {
+                      console.log(
+                        "미션 클릭:",
+                        missionRows[missionRow][missionCol]
+                      );
+                    }
                   }}
                 />
               ) : (

--- a/src/pages/mission/MissionOverviewPage.jsx
+++ b/src/pages/mission/MissionOverviewPage.jsx
@@ -13,7 +13,7 @@ function MissionOverviewPage() {
   const [missionLevels, setMissionLevels] = useState([]);
   const [challenges, setChallenges] = useState({});
   const [isSideModalOpen, setIsSideModalOpen] = useState(false);
-  const sideModalWidth = 400;
+  const sideModalWidth = 800;
 
   useEffect(() => {
     const fetchMissionGroups = async () => {

--- a/src/pages/mission/MissionOverviewPage.module.scss
+++ b/src/pages/mission/MissionOverviewPage.module.scss
@@ -66,3 +66,10 @@ ul.missionTab {
     display: flex;
   }
 }
+
+.missionDetail {
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+  flex: 1;
+}


### PR DESCRIPTION
사이드 모달이 추가 되었습니다.
```javascript
  const [isSideModalOpen, setIsSideModalOpen] = useState(false);
  const sideModalWidth = 800;
```
컴포넌트 함수 상단에 isSideModalOpen, sideModalWidth 넣으시고
적당한 위치에
```jsx
      <SideModal
        isOpen={isSideModalOpen}
        onClose={() => setIsSideModalOpen(false)}
        width={sideModalWidth}
      >
        <div className={styles.missionDetail}></div>
      </SideModal>
```
넣으시면 사이드 모달이 나옵니다.
들어갈 내용은 
```<div className={styles.missionDetail}></div>```
처럼 ```<SideModal ></SideModal>``` 사이에 넣으시면 됩니다.

![image](https://github.com/user-attachments/assets/b42f0377-cd48-47e2-8b7c-fb057dfa0d6c)
![image](https://github.com/user-attachments/assets/a66fc761-964c-4717-b6c6-22aaf6d334f8)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 미션 아이템 클릭 시 우측에서 슬라이드되는 사이드 모달이 열리는 기능이 추가되었습니다.
  * 사이드 모달은 미션 상세 정보를 표시할 수 있는 레이아웃을 제공합니다.

* **스타일**
  * 미션 상세 정보를 위한 새로운 레이아웃 스타일(.missionDetail)이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->