### PR TITLE
feat: 퀘스트 화면 및 대시보드 퀘스트 구현

### DIFF
--- a/src/components/Dashboard/DailyQuest.jsx
+++ b/src/components/Dashboard/DailyQuest.jsx
@@ -1,97 +1,46 @@
-import React from "react";
-import questSuccessIcon from "../../assets/images/daily-quest/quest-success.png";
-import questInprogressIcon from "../../assets/images/daily-quest/quest-inprogress.png";
+import React, { useEffect, useState } from "react";
 import styles from "./DailyQuest.module.scss";
 import { Link } from "react-router-dom";
 import { FaAngleRight } from "react-icons/fa6";
 import DailyQuestItem from "./DailyQuestItem";
+import apiInstance from "../../api/axiosInstance";
 
 function DailyQuest() {
-  const weeklyReward = {
-    currentPoints: 200,
-    maximumPoints: 500,
-    buttonText: "획득 완료",
-    status: "complete",
+  const [questList, setQuestList] = useState([]);
+
+  const fetchQuests = async () => {
+    try {
+      const response = await apiInstance.get("/api/v1/quest");
+      setQuestList(response.data.data || []);
+    } catch (err) {
+      console.error("퀘스트 불러오기 실패:", err);
+    }
   };
-  const quests = [
-    {
-      id: 1,
-      icon: questInprogressIcon,
-      title: "배움일기 댓글 작성",
-      progress: 0,
-      goal: 1,
-      buttonText: "50 포인트",
-      status: "inprogress",
-    },
-    {
-      id: 2,
-      icon: questInprogressIcon,
-      title: "미션 리워드 받기",
-      progress: 0,
-      goal: 1,
-      buttonText: "50 포인트",
-      status: "inprogress",
-    },
-    {
-      id: 3,
-      icon: questSuccessIcon,
-      title: "태스크 완료",
-      progress: 0,
-      goal: 1,
-      buttonText: "50 포인트",
-      status: "inprogress",
-    },
-    {
-      id: 4,
-      icon: questInprogressIcon,
-      title: "일일 퀘스트 완료",
-      progress: 0,
-      goal: 1,
-      buttonText: "50 포인트",
-      status: "inprogress",
-    },
-    {
-      id: 5,
-      icon: questSuccessIcon,
-      title: "배움일기 좋아요하기",
-      progress: 0,
-      goal: 1,
-      buttonText: "50 포인트",
-      status: "inprogress",
-    },
-  ];
+
+  useEffect(() => {
+    fetchQuests();
+  }, []);
+
   return (
-    <div className={styles.dailyQuest}>
-      <div>
-        <h3>데일리 퀘스트</h3>
-        <Link to="/daily-quest">
-          더보기 <FaAngleRight />
-        </Link>
-      </div>
-      <div>
-        <p>주간 리워드</p>
+      <div className={styles.dailyQuest}>
         <div>
-          <span>{weeklyReward.currentPoints}포인트</span>
-          <span> / {weeklyReward.maximumPoints}포인트</span>
-          <button className={weeklyReward.status}>
-            {weeklyReward.buttonText}
-          </button>
+          <h3>데일리 퀘스트</h3>
+          <Link to="/quest">
+            더보기 <FaAngleRight />
+          </Link>
         </div>
+        <ul>
+          {questList.map((quest) => (
+              <DailyQuestItem
+                  key={quest.userQuestId}
+                  title={quest.questName}
+                  progress={quest.progress}
+                  userQuestId={quest.userQuestId}
+                  onCompleted={fetchQuests}
+              />
+          ))}
+        </ul>
       </div>
-      <ul>
-        {quests.map((quest) => (
-          <DailyQuestItem
-            key={quest.id}
-            icon={quest.icon}
-            title={quest.title}
-            progress={quest.progress}
-            goal={quest.goal}
-            buttonText={quest.buttonText}
-            status={quest.status}
-          />
-        ))}
-      </ul>
-    </div>
   );
 }
 

--- a/src/components/Dashboard/DailyQuestItem.jsx
+++ b/src/components/Dashboard/DailyQuestItem.jsx
@@ -1,18 +1,70 @@
 import React from "react";
+import styles from "./DailyQuestItem.module.scss";
+import inprogressIcon from "../../assets/images/daily-quest/quest-inprogress.png";
+import completedIcon from "../../assets/images/daily-quest/quest-success.png";
+import apiInstance from "../../api/axiosInstance";
+import { useNavigate } from "react-router-dom";
 
-function DailyQuestItem({ icon, title, progress, goal, buttonText, status }) {
-  return (
-    <li>
-      <img src={icon} alt="퀘스트 아이콘" />
-      <div>
-        <span>{title}</span>
-        <span>
-          {progress}회 / {goal}회
-        </span>
-      </div>
-      <button className={status}>{buttonText}</button>
-    </li>
-  );
+function DailyQuestItem({ title, progress, userQuestId, onCompleted }) {
+    const navigate = useNavigate();
+
+    const getStatus = (progress) => {
+        switch (progress) {
+            case "완료 가능":
+                return { label: "완료 가능", icon: completedIcon, isClickable: true, color: "#007bff" };
+            case "완료됨":
+                return { label: "완료됨", icon: completedIcon, isClickable: false, color: "#007bff" };
+            default:
+                return { label: "진행중", icon: inprogressIcon, isClickable: false, color: "#aaa" };
+        }
+    };
+
+    const { label, icon, isClickable, color } = getStatus(progress);
+
+    const handleCompleteQuest = async (e) => {
+        e.stopPropagation();
+
+        if (!isClickable) return;
+
+        try {
+            await apiInstance.put(`/api/v1/quest/complete/${userQuestId}`);
+            alert("퀘스트 완료 처리됨!");
+            onCompleted();
+        } catch (error) {
+            console.error("퀘스트 완료 처리 중 오류 발생:", error);
+            alert("퀘스트 완료 처리 중 오류가 발생했습니다.");
+        }
+    };
+
+    const handleCardClick = () => {
+        let url = "/quest";
+        if (title.includes("출석")) url = "/dashboard";
+        else if (title.includes("미션")) url = "/mission";
+        else if (title.includes("일기")) url = "/diary";
+        else if (title.includes("칭찬")) url = "/praise";
+
+        navigate(url);
+    };
+
+    return (
+        <li className={styles.questItem} onClick={handleCardClick}>
+            <img src={icon} alt="퀘스트 상태 아이콘" className={styles.questIcon} />
+            <div className={styles.questTitle}>
+                <span>{title}</span>
+            </div>
+            <button
+                onClick={handleCompleteQuest}
+                disabled={!isClickable}
+                className={styles.questButton}
+                style={{
+                    backgroundColor: color,
+                    cursor: isClickable ? "pointer" : "default",
+                }}
+            >
+                {label}
+            </button>
+        </li>
+    );
 }
 
 export default DailyQuestItem;

--- a/src/components/Dashboard/DailyQuestItem.module.scss
+++ b/src/components/Dashboard/DailyQuestItem.module.scss
@@ -1,0 +1,24 @@
+.questItem {
+  display: flex;
+  align-items: center;
+  padding: 10px;
+  cursor: pointer;
+}
+
+.questIcon {
+  width: 24px;
+  height: 24px;
+  margin-right: 10px;
+}
+
+.questTitle {
+  flex-grow: 1;
+}
+
+.questButton {
+  padding: 5px 10px;
+  border: none;
+  border-radius: 4px;
+  color: white;
+  font-weight: bold;
+}

--- a/src/components/Quest/QuestItem.jsx
+++ b/src/components/Quest/QuestItem.jsx
@@ -1,33 +1,74 @@
 import React from "react";
 import styles from "./QuestItem.module.scss";
+import inprogressIcon from "../../assets/images/daily-quest/quest-inprogress.png";
+import completedIcon from "../../assets/images/daily-quest/quest-success.png";
+import apiInstance from "../../api/axiosInstance";
+import { useNavigate } from "react-router-dom";
 
-function QuestItem({
-  title,
-  description,
-  progress,
-  progressMax,
-  icon,
-  timeLeft,
-}) {
+function QuestItem({ title, progress, userQuestId, onCompleted }) {
+  const navigate = useNavigate();
+
+  const getStatus = (progress) => {
+    switch (progress) {
+      case "완료 가능":
+        return { label: "완료 가능", icon: completedIcon, isClickable: true, color: "#007bff" };
+      case "완료됨":
+        return { label: "완료됨", icon: completedIcon, isClickable: false, color: "#007bff" };
+      default:
+        return { label: "진행중", icon: inprogressIcon, isClickable: false, color: "#aaa" };
+    }
+  };
+
+  const { label, icon, isClickable, color } = getStatus(progress);
+
+  const handleCompleteQuest = async (e) => {
+    e.stopPropagation(); // 카드 클릭 이벤트와 중첩 방지
+
+    if (!isClickable) return;
+
+    await apiInstance.put(`/api/v1/quest/complete/${userQuestId}`);
+    alert("퀘스트 완료 처리됨!");
+    window.location.reload();
+
+  };
+
+  const handleCardClick = () => {
+    let url = "/quest"; // 기본 URL
+    if (title.includes("출석")) url = "/dashboard";
+    else if (title.includes("미션")) url = "/mission";
+    else if (title.includes("일기")) url = "/diary";
+    else if (title.includes("칭찬")) url = "/praise";
+
+    navigate(url);
+  };
+
   return (
-    <div className={[styles.questCard, styles.questBox].join(" ")}>
-      <div className={styles.questCardContent}>
-        <img src={icon} alt="아이콘" />
-        <div className={styles.questDetails}>
-          <h6>{title}</h6>
-          <div className={styles.questSubtitle}>{description}</div>
-          <div className={styles.questProgressText}>
-            <span className={styles.current}>{progress}</span> /{" "}
-            <span className={styles.total}>{progressMax}</span>회
+      <div
+          className={[styles.questCard, styles.questBox].join(" ")}
+          onClick={handleCardClick}
+          style={{ cursor: "pointer" }}
+      >
+        <div className={styles.questCardContent}>
+          <img src={icon} alt="퀘스트 상태 아이콘" />
+          <div className={styles.questDetails}>
+            <h6>{title}</h6>
           </div>
         </div>
+        <div className={styles.questButtonContainer}>
+          <button
+              onClick={handleCompleteQuest}
+              disabled={!isClickable}
+              style={{
+                backgroundColor: color,
+                color: "white",
+                cursor: isClickable ? "pointer" : "default",
+              }}
+              className={styles.questButton}
+          >
+            {label}
+          </button>
+        </div>
       </div>
-      <div className={styles.questButtonContainer}>
-        <button className={[styles.questButton]} disabled>
-          {timeLeft}
-        </button>
-      </div>
-    </div>
   );
 }
 

--- a/src/pages/Quest/AdminQuestPage.jsx
+++ b/src/pages/Quest/AdminQuestPage.jsx
@@ -1,0 +1,59 @@
+import React, { useState } from "react";
+import apiInstance from "../../api/axiosInstance";
+
+function AdminQuestPage() {
+    const [username, setUsername] = useState("");
+    const [message, setMessage] = useState("");
+
+    const handleAssignQuests = async () => {
+        if (!username) {
+            setMessage("⚠️ username을 입력해주세요.");
+            return;
+        }
+        try {
+            await apiInstance.post(`/api/v1/admin/quest/assign/${username}`);
+            setMessage(`✅ ${username}에게 퀘스트 할당 완료`);
+        } catch (error) {
+            console.error(error);
+            setMessage("❌ 퀘스트 할당 실패");
+        }
+    };
+
+    const handleResetQuests = async () => {
+        try {
+            await apiInstance.put("/api/v1/admin/quest/reset");
+            setMessage("✅ 퀘스트 리셋 완료");
+        } catch (error) {
+            console.error(error);
+            setMessage("❌ 퀘스트 리셋 실패");
+        }
+    };
+
+    return (
+        <div>
+            <h2>🛠️ Admin 퀘스트 페이지</h2>
+
+            <div>
+                <input
+                    type="text"
+                    placeholder="username 입력"
+                    value={username}
+                    onChange={(e) => setUsername(e.target.value)}
+                />
+                <button onClick={handleAssignQuests} >
+                    퀘스트 할당 (assign)
+                </button>
+            </div>
+
+            <div>
+                <button onClick={handleResetQuests}>
+                    퀘스트 리셋 (매일 자정 00:00시 주기적으로 호출되는 기능)
+                </button>
+            </div>
+
+            {message && <p>{message}</p>}
+        </div>
+    );
+}
+
+export default AdminQuestPage;

--- a/src/pages/Quest/QuestPage.jsx
+++ b/src/pages/Quest/QuestPage.jsx
@@ -1,93 +1,44 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import styles from "./QuestPage.module.scss";
-import questInProgressIcon from "../../assets/images/daily-quest/quest-inprogress.png";
 import QuestItem from "../../components/Quest/QuestItem";
-
-function getDailyQuestItems() {
-  return [
-    {
-      title: "배움일기 작성",
-      description: "학습 내용을 정리하고 회고해요",
-      progress: 0,
-      progressMax: 1,
-      icon: questInProgressIcon,
-      timeLeft: "0일 12시간 남음",
-    },
-    {
-      title: "배움일기 작성",
-      description: "학습 내용을 정리하고 회고해요",
-      progress: 0,
-      progressMax: 1,
-      icon: questInProgressIcon,
-      timeLeft: "0일 12시간 남음",
-    },
-    {
-      title: "배움일기 작성",
-      description: "학습 내용을 정리하고 회고해요",
-      progress: 0,
-      progressMax: 1,
-      icon: questInProgressIcon,
-      timeLeft: "0일 12시간 남음",
-    },
-    {
-      title: "배움일기 작성",
-      description: "학습 내용을 정리하고 회고해요",
-      progress: 0,
-      progressMax: 1,
-      icon: questInProgressIcon,
-      timeLeft: "0일 12시간 남음",
-    },
-    {
-      title: "배움일기 작성",
-      description: "학습 내용을 정리하고 회고해요",
-      progress: 0,
-      progressMax: 1,
-      icon: questInProgressIcon,
-      timeLeft: "0일 12시간 남음",
-    },
-  ];
-}
+import apiInstance from "../../api/axiosInstance";
 
 function QuestPage() {
-  const dailyQuestItems = getDailyQuestItems();
+  const [questList, setQuestList] = useState([]);
+
+  const fetchQuests = async () => {
+    try {
+      const response = await apiInstance.get("/api/v1/quest");
+      setQuestList(response.data.data || []);
+    } catch (err) {
+      console.error("퀘스트 불러오기 실패:", err);
+    }
+  };
+
+  useEffect(() => {
+    fetchQuests();
+  }, []);
+
   return (
-    <div>
-      <h2 className={styles.questPageTitle}>퀘스트</h2>
-      <div className={styles.alert}>
-        오늘 하루 최대 100포인트를 모두 획득하셨어요. 고생하셨습니다!
-      </div>
+      <div>
+        <h2 className={styles.questPageTitle}>퀘스트</h2>
 
-      <div className={[styles.cardWeekly, styles.questBox].join(" ")}>
-        <h5>일일 퀘스트</h5>
+        <div className={[styles.cardWeekly, styles.questBox].join(" ")}>
+          <h5>일일 퀘스트</h5>
 
-        <div className={styles.weeklyReward}>
-          <div className={styles.weeklyRewardLabel}>주간 리워드</div>
-          <div className={styles.weeklyRewardPoints}>
-            <div className={styles.current}>300</div>
-            <div className={styles.total}>/ 500 포인트</div>
+          <div className={styles.questList}>
+            {questList.map((quest) => (
+                <QuestItem
+                    key={quest.userQuestId}
+                    title={quest.questName}
+                    progress={quest.progress}
+                    userQuestId={quest.userQuestId}
+                    onCompleted={fetchQuests}
+                />
+            ))}
           </div>
-          <progress
-            className={styles.progressBar}
-            value="60"
-            max="100"
-          ></progress>
-        </div>
-
-        <div className={styles.questList}>
-          {dailyQuestItems.map((quest, index) => (
-            <QuestItem
-              key={index}
-              title={quest.title}
-              description={quest.description}
-              progress={quest.progress}
-              progressMax={quest.progressMax}
-              icon={quest.icon}
-              timeLeft={quest.timeLeft}
-            />
-          ))}
         </div>
       </div>
-    </div>
   );
 }
 

--- a/src/routes/user.routes.jsx
+++ b/src/routes/user.routes.jsx
@@ -9,6 +9,7 @@ import MyInfoPage from "../pages/User/MyInfoPage";
 import ShopPage from "../pages/shop/ShopPage";
 import ShopHistoryPage from "../pages/Shop/ShopHistoryPage";
 import AdminShopPage from "../pages/Shop/AdminShopPage";
+import AdminQuestPage from "../pages/Quest/AdminQuestPage";
 
 export default [
   {
@@ -57,6 +58,10 @@ export default [
         path: "/adminShop",
         element: <AdminShopPage />
       },
+      {
+        path: "/adminQuest",
+        element: <AdminQuestPage />
+      }
       // { path: "/settings", element: <SettingsPage /> },
       // ... 추가 사용자 경로
     ],


### PR DESCRIPTION
## 구현 사항
- /dashboard : 우측 하단에 퀘스트 요소 표시
- /quest : 사용자의 현재 퀘스트 클리어 현황 및 완료 버튼 구현, 퀘스트 수행 경로로 리다이렉트 구현
- /adminQuest : 관리자 퀘스트 화면
![image](https://github.com/user-attachments/assets/e4b01a53-69df-40fc-aaf3-7a903dfd53e3)
![image](https://github.com/user-attachments/assets/8642cb1d-a862-4aee-9af6-ebc46c34b9fa)
