### PR TITLE
Feature/#34 미션 그룹 홈, 학습계획 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "hugexp-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@hello-pangea/dnd": "^18.0.1",
         "axios": "^1.10.0",
         "i": "^0.3.7",
         "jwt-decode": "^4.0.0",
@@ -268,6 +269,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -926,6 +936,23 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hello-pangea/dnd": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/@hello-pangea/dnd/-/dnd-18.0.1.tgz",
+      "integrity": "sha512-xojVWG8s/TGrKT1fC8K2tIWeejJYTAeJuj36zM//yEm/ZrnZUSFGS15BpO+jGZT1ybWvyXmeDJwPYb4dhWlbZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.7",
+        "css-box-model": "^1.2.1",
+        "raf-schd": "^4.0.3",
+        "react-redux": "^9.2.0",
+        "redux": "^5.0.1"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1729,6 +1756,12 @@
       "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==",
       "license": "MIT"
     },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.5.1.tgz",
@@ -2049,6 +2082,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-invariant": "^1.0.6"
       }
     },
     "node_modules/css-color-keywords": {
@@ -3252,6 +3294,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
@@ -3280,6 +3328,29 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "*"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -3343,6 +3414,12 @@
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -3570,6 +3647,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -3659,6 +3742,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@hello-pangea/dnd": "^18.0.1",
     "axios": "^1.10.0",
     "i": "^0.3.7",
     "jwt-decode": "^4.0.0",

--- a/src/api/missionService.js
+++ b/src/api/missionService.js
@@ -73,3 +73,26 @@ export const changeMissionTaskState = async (taskId, state) => {
     throw error;
   }
 };
+
+export const getMissionGroupMembers = async (groupId) => {
+  try {
+    const response = await api.get(`/api/v1/mission-groups/${groupId}/users`);
+    return response.data;
+  } catch (error) {
+    console.error("미션 그룹 멤버 가져오기 실패:", error);
+    throw error;
+  }
+};
+
+export const changeChallengeState = async (challengeId, state) => {
+  try {
+    const response = await api.patch(
+      `/api/v1/challenges/${challengeId}?newProgress=${state}`,
+      "no content"
+    );
+    return response.data;
+  } catch (error) {
+    console.error("챌린지 상태 변경 실패:", error);
+    throw error;
+  }
+};

--- a/src/components/Mission/MissionBoard.jsx
+++ b/src/components/Mission/MissionBoard.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+function MissionBoard() {
+  return <div>MissionBoard</div>;
+}
+
+export default MissionBoard;

--- a/src/components/Mission/MissionBoard.jsx
+++ b/src/components/Mission/MissionBoard.jsx
@@ -1,7 +1,147 @@
-import React from "react";
+import React, { useEffect, useState, useRef } from "react";
+import { DragDropContext, Droppable, Draggable } from "@hello-pangea/dnd";
+import "./MissionBoard.module.scss";
+import styles from "./MissionBoard.module.scss";
+import { myChallenges, changeChallengeState } from "../../api/missionService";
 
-function MissionBoard() {
-  return <div>MissionBoard</div>;
+/* 1. 컬럼 정의 */
+const COLUMNS = [
+  { id: "NOT_STARTED", title: "시작 전" },
+  { id: "ABORTED", title: "중단 됨" },
+  { id: "IN_PROGRESS", title: "진행 중" },
+  { id: "COMPLETED", title: "완료" },
+  { id: "IN_FEEDBACK", title: "피드백 중" },
+  { id: "FEEDBACK_DONE", title: "피드백 완료" }, // FEEDBACK_COMPLETED + REWARD_RECEIVED
+];
+
+/* 3. state별 배열로 묶어 state화 */
+function groupByState(list) {
+  const grouped = {};
+  COLUMNS.forEach((c) => (grouped[c.id] = []));
+  list.forEach((t) => grouped[t.progress].push(t));
+  return grouped;
+}
+
+function MissionBoard({ groupId }) {
+  const [missions, setMissions] = useState([]);
+  const [columns, setColumns] = useState(groupByState([]));
+  const pendingRequests = useRef(new Set());
+
+  useEffect(() => {
+    const fetchMissions = async () => {
+      try {
+        const response = await myChallenges(groupId);
+        console.log("Fetched missions:", response.data);
+        const newMissions = response.data.map((mission) => ({
+          ...mission,
+          kId: "k" + mission.id,
+        }));
+        setMissions(newMissions);
+      } catch (error) {
+        console.error("미션을 가져오는 데 실패했습니다:", error);
+      }
+    };
+
+    fetchMissions();
+  }, [groupId]);
+
+  useEffect(() => {
+    setColumns(groupByState(missions));
+  }, [missions]);
+
+  /* 4. 드래그 종료 시 state 갱신 */
+  const onDragEnd = ({ source, destination }) => {
+    //draggableId
+    if (!destination) return; // 밖으로 놓기 → 무시
+    if (destination.droppableId === "FEEDBACK_DONE") return;
+    if (
+      source.droppableId === destination.droppableId &&
+      source.index === destination.index
+    )
+      return; // 제자리 → 무시
+
+    setColumns((prev) => {
+      // 1) 원본 컬럼 배열 복사
+      const sourceTasks = Array.from(prev[source.droppableId]);
+      // 2) 꺼낸 카드
+      const [moved] = sourceTasks.splice(source.index, 1);
+
+      // 3) 목적지 컬럼 배열 복사(같은 컬럼이면 sourceTasks 사용)
+      const destTasks =
+        source.droppableId === destination.droppableId
+          ? sourceTasks
+          : Array.from(prev[destination.droppableId]);
+
+      // 4) state 바꿔주고 삽입
+      moved.progress = destination.droppableId;
+      handleStateChangeOnce(moved.id, destination.droppableId);
+      destTasks.splice(destination.index, 0, moved);
+
+      return {
+        ...prev,
+        [source.droppableId]: sourceTasks,
+        [destination.droppableId]: destTasks,
+      };
+    });
+  };
+
+  const handleStateChangeOnce = async (missionId, newState) => {
+    const requestKey = `${missionId}-${newState}`;
+
+    if (pendingRequests.current.has(requestKey)) {
+      return; // 이미 요청 중이면 무시
+    }
+
+    pendingRequests.current.add(requestKey);
+
+    try {
+      await changeChallengeState(missionId, newState);
+      console.log(`미션 ${missionId} 상태 변경 완료: ${newState}`);
+    } catch (error) {
+      console.error("상태 변경 실패:", error);
+    } finally {
+      pendingRequests.current.delete(requestKey);
+    }
+  };
+
+  return (
+    <DragDropContext onDragEnd={onDragEnd} className={styles.kanbanBoard}>
+      <div className={styles.board}>
+        {COLUMNS.map((col) => (
+          <Droppable droppableId={col.id} key={col.id}>
+            {(provided, snapshot) => (
+              <div
+                className={`${styles.column} ${
+                  snapshot.isDraggingOver ? styles.draggingOver : ""
+                }`}
+                ref={provided.innerRef}
+                {...provided.droppableProps}
+              >
+                <h3>{col.title}</h3>
+
+                {columns[col.id].map((task, idx) => (
+                  <Draggable key={task.kId} draggableId={task.kId} index={idx}>
+                    {(prov, snap) => (
+                      <div
+                        className={`${styles.card} ${snap.isDragging ? styles.dragging : ""}`}
+                        ref={prov.innerRef}
+                        {...prov.draggableProps}
+                        {...prov.dragHandleProps}
+                      >
+                        {task.mission.name}
+                      </div>
+                    )}
+                  </Draggable>
+                ))}
+
+                {provided.placeholder /* 공간 유지용 */}
+              </div>
+            )}
+          </Droppable>
+        ))}
+      </div>
+    </DragDropContext>
+  );
 }
 
 export default MissionBoard;

--- a/src/components/Mission/MissionBoard.module.scss
+++ b/src/components/Mission/MissionBoard.module.scss
@@ -1,0 +1,48 @@
+.kanbanBoard {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  border-radius: 8px;
+}
+
+.board {
+  display: flex;
+  gap: 12px;
+  padding: 12px;
+  overflow-x: auto;
+  height: 100%;
+}
+
+.column {
+  flex: 0 0 300px;
+  background: #f4f5f7;
+  border-radius: 6px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  max-height: 100%;
+
+  &.draggingOver {
+    background: #dfe3ff;
+  }
+
+  h3 {
+    margin: 0 0 10px;
+    font-size: 16px;
+  }
+}
+
+.card {
+  background: #ffffff;
+  border-radius: 4px;
+  padding: 8px;
+  margin-bottom: 8px;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.12);
+  cursor: grab;
+  user-select: none;
+}
+
+.card.dragging {
+  background: #e3fcef;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.25);
+}

--- a/src/components/Mission/MissionHome.jsx
+++ b/src/components/Mission/MissionHome.jsx
@@ -1,7 +1,50 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import styles from "./MissionHome.module.scss";
+import { getMissionGroupMembers } from "../../api/missionService";
+import emptyUserProfile from "../../assets/images/user/empty-user-profile.svg";
 
-function MissionHome() {
-  return <div>MissionHome</div>;
+function MissionHome({ groupId }) {
+  const [groupMembers, setGroupMembers] = useState([]);
+
+  useEffect(() => {
+    const fetchGroupMembers = async () => {
+      try {
+        const members = await getMissionGroupMembers(groupId);
+        setGroupMembers(members.data);
+      } catch (error) {
+        console.error("Failed to fetch group members:", error);
+      }
+    };
+
+    fetchGroupMembers();
+  }, [groupId]);
+
+  if (!groupId) {
+    return <div>그룹 ID가 없습니다.</div>;
+  }
+
+  return (
+    <div className={styles.missionHome}>
+      <div>
+        <h4>팀 소개</h4>
+        <p></p>
+      </div>
+      <div>
+        <h4>
+          멤버{" "}
+          <span className={styles.memberCount}>{groupMembers.length}명</span>
+        </h4>
+        <ul className={styles.memberList}>
+          {groupMembers.map((member) => (
+            <li key={member.username}>
+              <img src={member.profileImage || emptyUserProfile} />
+              <span>{member.name || "이름 없음"}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
 }
 
 export default MissionHome;

--- a/src/components/Mission/MissionHome.jsx
+++ b/src/components/Mission/MissionHome.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+function MissionHome() {
+  return <div>MissionHome</div>;
+}
+
+export default MissionHome;

--- a/src/components/Mission/MissionHome.module.scss
+++ b/src/components/Mission/MissionHome.module.scss
@@ -1,0 +1,63 @@
+.missionHome {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  border: 1px solid #e0e0e0;
+  border-radius: 5px;
+
+  h4 {
+    margin: 0;
+    margin-top: 20px;
+    padding-left: 40px;
+    font-size: 16px;
+    color: #333;
+  }
+
+  p {
+    margin: 0;
+    padding: 20px;
+    font-size: 14px;
+    color: #666;
+  }
+}
+
+.memberCount {
+  font-size: 12px;
+  color: #333;
+  background-color: #e0e0e0;
+  padding: 1px 10px;
+  border-radius: 10px;
+}
+
+ul.memberList {
+  list-style: none;
+  padding: 20px;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+
+  li {
+    display: flex;
+    align-items: center;
+    padding: 5px;
+    margin: 0;
+
+    &:hover {
+      background-color: #f7f7fa;
+      border-radius: 5px;
+      cursor: pointer;
+    }
+
+    img {
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      margin-right: 10px;
+    }
+
+    span {
+      font-size: 14px;
+      color: #333;
+    }
+  }
+}

--- a/src/components/common/Sidebar/Sidebar.jsx
+++ b/src/components/common/Sidebar/Sidebar.jsx
@@ -20,6 +20,8 @@ import logo from "../../../assets/images/logo.png";
 import { useNavigate } from "react-router-dom";
 import useUserStore from "../../../stores/userStore";
 import SidebarUserMenu from "./SidebarUserMenu";
+import SidebarMissionGroup from "./SidebarMissionGroup";
+import { getMyMissionGroups } from "../../../api/missionService";
 
 function getQuickMenuItems() {
   return [
@@ -41,23 +43,27 @@ function getMenuItems() {
   ];
 }
 
-function getMissonGroupItems() {
-  return [
-    {
-      title: "Hugton 알고리즘 미션 강좌",
-      items: [{ label: "홈" }, { label: "학습계획" }],
-    },
-  ];
-}
-
 function Sidebar() {
   const quickMenuItems = getQuickMenuItems();
   const menuItems = getMenuItems();
-  const missionGroupItems = getMissonGroupItems();
+  // const missionGroupItems = getMissonGroupItems();
   const navigate = useNavigate();
   const userInfo = useUserStore((state) => state.userInfo);
   const [userMenuToggle, setUserMenuToggle] = useState(false);
   const userMenuRef = useRef(null);
+  const [missionGroupItems, setMissionGroupItems] = useState([]);
+
+  useEffect(() => {
+    const fetchMissionGroups = async () => {
+      try {
+        const response = await getMyMissionGroups();
+        setMissionGroupItems(response.data);
+      } catch (error) {
+        console.error("미션 그룹을 가져오는 데 실패했습니다:", error);
+      }
+    };
+    fetchMissionGroups();
+  }, []);
 
   useEffect(() => {
     const handleClickOutside = (e) => {
@@ -77,86 +83,77 @@ function Sidebar() {
   }
 
   return (
-      <div className={styles.sidebar}>
-        <div>
-          <div className={styles.sidebarHeader}>
-            <div>
-              <FaBuilding />
-              <span>EDUCATION</span>
-            </div>
-            <div>
-              <FaAnglesLeft />
-            </div>
+    <div className={styles.sidebar}>
+      <div>
+        <div className={styles.sidebarHeader}>
+          <div>
+            <FaBuilding />
+            <span>EDUCATION</span>
           </div>
-          <div className={styles.sidebarTitle}>
-            <img src={logo} alt="Logo" />
-            <span>허그톤 비욘드호라이즌</span>
-          </div>
-          <hr />
-          <div className={styles.menuList}>
-            <ul>
-              {quickMenuItems.map((item, index) => (
-                  <li key={index}>
-                    {item.icon}
-                    <span>{item.label}</span>
-                  </li>
-              ))}
-            </ul>
-            <hr />
-            <ul>
-              {menuItems.map((item, index) => (
-                  <li
-                      key={index}
-                      onClick={() => {
-                        navigate(item.link || "/");
-                      }}
-                  >
-                    {item.icon}
-                    <span>{item.label}</span>
-                  </li>
-              ))}
-              <hr />
-            </ul>
-            {missionGroupItems.map((groupItem, index) => (
-                <div key={index} className={styles.missionGroup}>
-                  <ul>
-                    <li className={styles.missionGroupTitle}>{groupItem.title}</li>
-                    {groupItem.items.map((item, idx) => (
-                        <li key={idx}>
-                          <span>{item.label}</span>
-                        </li>
-                    ))}
-                  </ul>
-                </div>
-            ))}
+          <div>
+            <FaAnglesLeft />
           </div>
         </div>
-        <div className={styles.userInfo}>
-          <div className={styles.userStats}>
-            <div>
-              Lv. <span>{userInfo.level}</span>
-            </div>
-            <div>
-              <span>{userInfo.currentTotalExp}</span>개
-            </div>
-          </div>
-          <div className={styles.userProfile} ref={userMenuRef}>
-            <div>
-              <img
-                  src={
-                    userInfo?.profileImage
-                        ? `${api.defaults.baseURL}${userInfo.profileImage}`
-                        : emptyUserProfile
-                  }
-                  alt={userInfo?.name || "사용자 프로필"}
-                  onClick={() => setUserMenuToggle(!userMenuToggle)}
-              />
-              {userMenuToggle && <SidebarUserMenu />}
-            </div>
-            <span>©hug Inc.</span>
-          </div>
+        <div className={styles.sidebarTitle}>
+          <img src={logo} alt="Logo" />
+          <span>허그톤 비욘드호라이즌</span>
+        </div>
+        <hr />
+        <div className={styles.menuList}>
+          <ul>
+            {quickMenuItems.map((item, index) => (
+              <li key={index}>
+                {item.icon}
+                <span>{item.label}</span>
+              </li>
+            ))}
+          </ul>
+          <hr />
+          <ul>
+            {menuItems.map((item, index) => (
+              <li
+                key={index}
+                onClick={() => {
+                  navigate(item.link || "/");
+                }}
+              >
+                {item.icon}
+                <span>{item.label}</span>
+              </li>
+            ))}
+            <hr />
+          </ul>
+          {missionGroupItems && missionGroupItems.length > 0 && (
+            <SidebarMissionGroup missionGroupItems={missionGroupItems} />
+          )}
         </div>
       </div>
+      <div className={styles.userInfo}>
+        <div className={styles.userStats}>
+          <div>
+            Lv. <span>{userInfo.level}</span>
+          </div>
+          <div>
+            <span>{userInfo.point}</span>개
+          </div>
+        </div>
+        <div className={styles.userProfile} ref={userMenuRef}>
+          <div>
+            <img
+              src={
+                userInfo?.profileImage
+                  ? `${api.defaults.baseURL}${userInfo.profileImage}`
+                  : emptyUserProfile
+              }
+              alt={userInfo?.name || "사용자 프로필"}
+              onClick={() => setUserMenuToggle(!userMenuToggle)}
+            />
+            {userMenuToggle && <SidebarUserMenu />}
+          </div>
+          <span>©hug Inc.</span>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/src/components/common/Sidebar/Sidebar.jsx
+++ b/src/components/common/Sidebar/Sidebar.jsx
@@ -38,7 +38,7 @@ function getMenuItems() {
     { icon: <FaThumbsUp />, label: "칭찬", link: "/praises" },
     { icon: <FaGraduationCap />, label: "미션", link: "/mission" },
     { icon: <FaChessBoard />, label: "퀘스트", link: "/quest" },
-    { icon: <FaCartShopping />, label: "상점" },
+    { icon: <FaCartShopping />, label: "상점", link: "/shop" },
     { icon: <FaRankingStar />, label: "랭킹" },
   ];
 }

--- a/src/components/common/Sidebar/Sidebar.jsx
+++ b/src/components/common/Sidebar/Sidebar.jsx
@@ -36,7 +36,7 @@ function getMenuItems() {
     { icon: <FaHouse />, label: "홈" },
     { icon: <FaBook />, label: "배움일기" },
     { icon: <FaThumbsUp />, label: "칭찬", link: "/praises" },
-    { icon: <FaGraduationCap />, label: "미션", link: "/missions" },
+    { icon: <FaGraduationCap />, label: "미션", link: "/mission" },
     { icon: <FaChessBoard />, label: "퀘스트", link: "/quest" },
     { icon: <FaCartShopping />, label: "상점" },
     { icon: <FaRankingStar />, label: "랭킹" },

--- a/src/components/common/Sidebar/Sidebar.module.scss
+++ b/src/components/common/Sidebar/Sidebar.module.scss
@@ -67,11 +67,6 @@
         font-size: 14px;
         cursor: pointer;
 
-        &.missionGroupTitle {
-          overflow: hidden;
-          text-overflow: ellipsis;
-        }
-
         &:hover {
           background-color: rgba(0, 0, 0, 0.05);
         }

--- a/src/components/common/Sidebar/SidebarMissionGroup.jsx
+++ b/src/components/common/Sidebar/SidebarMissionGroup.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+import styles from "./SidebarMissionGroup.module.scss";
+
+function SidebarMissionGroup({ missionGroupItems }) {
+  return (
+    <>
+      {missionGroupItems.map((groupItem, index) => (
+        <div key={index} className={styles.missionGroup}>
+          <ul>
+            <li className={styles.missionGroupTitle}>
+              <span
+                className={[
+                  styles.missionGroupTitleLetter,
+                  styles[`no_${index % 10}`],
+                ].join(" ")}
+              >
+                {groupItem.missionGroup.name
+                  .substring(0, 1)
+                  .concat(
+                    groupItem.missionGroup.name.length > 1 &&
+                      groupItem.missionGroup.name.split(" ")[1]
+                      ? groupItem.missionGroup.name
+                          .split(" ")[1]
+                          .substring(0, 1)
+                      : groupItem.missionGroup.name.substring(1, 2)
+                  )}
+              </span>
+              {groupItem.missionGroup.name}
+            </li>
+            <ul>
+              <li className={styles.missionGroupItem}>
+                <span>홈</span>
+              </li>
+              <li className={styles.missionGroupItem}>
+                <span>학습계획</span>
+              </li>
+            </ul>
+          </ul>
+        </div>
+      ))}
+    </>
+  );
+}
+
+export default SidebarMissionGroup;

--- a/src/components/common/Sidebar/SidebarMissionGroup.jsx
+++ b/src/components/common/Sidebar/SidebarMissionGroup.jsx
@@ -1,7 +1,14 @@
 import React from "react";
 import styles from "./SidebarMissionGroup.module.scss";
+import { useNavigate } from "react-router-dom";
 
 function SidebarMissionGroup({ missionGroupItems }) {
+  const navigate = useNavigate();
+
+  const handleItemClick = (missionGroupId, componentType) => {
+    navigate(`/mission-group/${missionGroupId}/${componentType}`);
+  };
+
   return (
     <>
       {missionGroupItems.map((groupItem, index) => (
@@ -28,10 +35,20 @@ function SidebarMissionGroup({ missionGroupItems }) {
               {groupItem.missionGroup.name}
             </li>
             <ul>
-              <li className={styles.missionGroupItem}>
+              <li
+                className={styles.missionGroupItem}
+                onClick={() =>
+                  handleItemClick(groupItem.missionGroup.id, "home")
+                }
+              >
                 <span>홈</span>
               </li>
-              <li className={styles.missionGroupItem}>
+              <li
+                className={styles.missionGroupItem}
+                onClick={() =>
+                  handleItemClick(groupItem.missionGroup.id, "learning-plan")
+                }
+              >
                 <span>학습계획</span>
               </li>
             </ul>

--- a/src/components/common/Sidebar/SidebarMissionGroup.module.scss
+++ b/src/components/common/Sidebar/SidebarMissionGroup.module.scss
@@ -1,0 +1,51 @@
+.missionGroupTitle {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.missionGroupTitleLetter {
+  font-weight: bold;
+  color: white;
+  border-radius: 5px;
+  height: 24px;
+  width: 24px;
+  text-align: center;
+  line-height: 24px;
+  margin: -4px;
+  margin-right: 5px;
+  font-size: 9px !important;
+  &.no_0 {
+    background-color: #3498db;
+  }
+  &.no_1 {
+    background-color: #e74c3c;
+  }
+  &.no_2 {
+    background-color: #8e44ad;
+  }
+  &.no_3 {
+    background-color: #f1c40f;
+  }
+  &.no_4 {
+    background-color: #11a2ad;
+  }
+  &.no_5 {
+    background-color: #af254c;
+  }
+  &.no_6 {
+    background-color: #9b59b6;
+  }
+  &.no_7 {
+    background-color: #e67e22;
+  }
+  &.no_8 {
+    background-color: #2ecc71;
+  }
+  &.no_9 {
+    background-color: #181818;
+  }
+}
+
+.missionGroupItem {
+  padding-left: 30px !important;
+}

--- a/src/components/common/TabComponent/TabComponent.jsx
+++ b/src/components/common/TabComponent/TabComponent.jsx
@@ -1,13 +1,19 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styles from "./TabComponent.module.scss";
 
-function TabComponent({ tabs, onTabChange }) {
-  const [activeTab, setActiveTab] = useState(tabs[0]);
+function TabComponent({ tabs, active, onTabChange }) {
+  const [activeTab, setActiveTab] = useState(active || tabs[0]);
 
   const handleTabChange = (tab) => {
     setActiveTab(tab);
     onTabChange(tab);
   };
+
+  useEffect(() => {
+    if (active) {
+      setActiveTab(active);
+    }
+  }, [active]);
 
   return (
     <ul className={styles.tabList}>

--- a/src/components/common/TabComponent/TabComponent.jsx
+++ b/src/components/common/TabComponent/TabComponent.jsx
@@ -1,0 +1,31 @@
+import React, { useState } from "react";
+import styles from "./TabComponent.module.scss";
+
+function TabComponent({ tabs, onTabChange }) {
+  const [activeTab, setActiveTab] = useState(tabs[0]);
+
+  const handleTabChange = (tab) => {
+    setActiveTab(tab);
+    onTabChange(tab);
+  };
+
+  return (
+    <ul className={styles.tabList}>
+      {/* MissionTab */}
+      {tabs.map((tab) => (
+        <li
+          key={tab.id}
+          className={tab.id === activeTab.id ? styles.active : ""}
+          onClick={() => {
+            handleTabChange(tab);
+          }}
+        >
+          {tab.name}
+        </li>
+      ))}
+      <li>&nbsp;</li>
+    </ul>
+  );
+}
+
+export default TabComponent;

--- a/src/components/common/TabComponent/TabComponent.module.scss
+++ b/src/components/common/TabComponent/TabComponent.module.scss
@@ -1,0 +1,33 @@
+ul.tabList {
+  display: flex;
+  flex-direction: row;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  margin-bottom: 20px;
+
+  li {
+    text-align: center;
+    font-size: 16px;
+    padding: 10px;
+    cursor: pointer;
+    border-bottom: #e0e0e0 2px solid;
+
+    &.active {
+      color: #609ae9;
+      border-bottom-color: #609ae9;
+    }
+
+    &:hover {
+      border-bottom-color: #609ae9;
+    }
+
+    &:last-child {
+      flex: 1;
+      cursor: default;
+      &:hover {
+        border-bottom-color: #e0e0e0;
+      }
+    }
+  }
+}

--- a/src/pages/mission/MissionGroupPage.jsx
+++ b/src/pages/mission/MissionGroupPage.jsx
@@ -1,8 +1,9 @@
-import React, { useState } from "react";
+import React from "react";
 import TabComponent from "../../components/common/TabComponent/TabComponent";
 import MissionHome from "../../components/Mission/MissionHome";
 import MissionBoard from "../../components/Mission/MissionBoard";
 import { useNavigate, useParams } from "react-router-dom";
+import styles from "./MissionGroupPage.module.scss";
 
 function MissionGroupPage({ componentType }) {
   const navigate = useNavigate();
@@ -12,18 +13,23 @@ function MissionGroupPage({ componentType }) {
     { id: 2, name: "학습계획", componentType: "learning-plan" },
   ];
   return (
-    <div>
+    <div className={styles.missionGroupPage}>
       <h2>미션</h2>
       <TabComponent
         tabs={tabs}
+        active={{
+          id: tabs.find((tab) => tab.componentType === componentType).id,
+        }}
         onTabChange={(item) => {
           navigate(`/mission-group/${missionGroupId}/${item.componentType}`, {
             replace: true,
           });
         }}
       />
-      {componentType == "home" && <MissionHome />}
-      {componentType == "learning-plan" && <MissionBoard />}
+      {componentType == "home" && <MissionHome groupId={missionGroupId} />}
+      {componentType == "learning-plan" && (
+        <MissionBoard groupId={missionGroupId} />
+      )}
     </div>
   );
 }

--- a/src/pages/mission/MissionGroupPage.jsx
+++ b/src/pages/mission/MissionGroupPage.jsx
@@ -1,0 +1,31 @@
+import React, { useState } from "react";
+import TabComponent from "../../components/common/TabComponent/TabComponent";
+import MissionHome from "../../components/Mission/MissionHome";
+import MissionBoard from "../../components/Mission/MissionBoard";
+import { useNavigate, useParams } from "react-router-dom";
+
+function MissionGroupPage({ componentType }) {
+  const navigate = useNavigate();
+  const { missionGroupId } = useParams();
+  const tabs = [
+    { id: 1, name: "홈", componentType: "home" },
+    { id: 2, name: "학습계획", componentType: "learning-plan" },
+  ];
+  return (
+    <div>
+      <h2>미션</h2>
+      <TabComponent
+        tabs={tabs}
+        onTabChange={(item) => {
+          navigate(`/mission-group/${missionGroupId}/${item.componentType}`, {
+            replace: true,
+          });
+        }}
+      />
+      {componentType == "home" && <MissionHome />}
+      {componentType == "learning-plan" && <MissionBoard />}
+    </div>
+  );
+}
+
+export default MissionGroupPage;

--- a/src/pages/mission/MissionGroupPage.module.scss
+++ b/src/pages/mission/MissionGroupPage.module.scss
@@ -1,0 +1,7 @@
+.missionGroupPage {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 100vh;
+  height: 100%;
+}

--- a/src/pages/mission/MissionOverviewPage.jsx
+++ b/src/pages/mission/MissionOverviewPage.jsx
@@ -9,6 +9,7 @@ import {
 } from "../../api/missionService";
 import SideModal from "../../components/common/SideModal/SideModal";
 import MissionDetailCard from "../../components/Mission/MissionDetailCard";
+import TabComponent from "../../components/common/TabComponent/TabComponent";
 
 function MissionOverviewPage() {
   const [missionGroups, setMissionGroups] = useState([]);
@@ -25,7 +26,14 @@ function MissionOverviewPage() {
     const fetchMissionGroups = async () => {
       try {
         const groups = await getMyMissionGroups();
-        setMissionGroups(groups.data);
+        const newGroups = [];
+        groups.data.forEach((group) => {
+          newGroups.push({
+            ...group,
+            name: group.missionGroup.name,
+          });
+        });
+        setMissionGroups(newGroups);
       } catch (error) {
         console.error("미션 그룹을 가져오는 데 실패했습니다:", error);
       }
@@ -118,23 +126,12 @@ function MissionOverviewPage() {
   return (
     <div>
       <h2>미션</h2>
-      <ul className={styles.missionTab}>
-        {/* MissionTab */}
-        {missionGroups.map((group) => (
-          <li
-            key={group.missionGroup.id}
-            className={
-              group.missionGroup.id === activeGroup.id ? styles.active : ""
-            }
-            onClick={() => {
-              setActiveGroup(group.missionGroup);
-            }}
-          >
-            {group.missionGroup.name}
-          </li>
-        ))}
-        <li>&nbsp;</li>
-      </ul>
+      <TabComponent
+        tabs={missionGroups}
+        onTabChange={(item) => {
+          setActiveGroup(item.missionGroup);
+        }}
+      />
       <div className={styles.missionTabPage}>
         <ul className={styles.missionLevel}>
           {missionLevels.map((level, index) => (

--- a/src/pages/mission/MissionOverviewPage.module.scss
+++ b/src/pages/mission/MissionOverviewPage.module.scss
@@ -1,37 +1,3 @@
-ul.missionTab {
-  display: flex;
-  flex-direction: row;
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  margin-bottom: 20px;
-
-  li {
-    text-align: center;
-    font-size: 16px;
-    padding: 10px;
-    cursor: pointer;
-    border-bottom: #e0e0e0 2px solid;
-
-    &.active {
-      color: #609ae9;
-      border-bottom-color: #609ae9;
-    }
-
-    &:hover {
-      border-bottom-color: #609ae9;
-    }
-
-    &:last-child {
-      flex: 1;
-      cursor: default;
-      &:hover {
-        border-bottom-color: #e0e0e0;
-      }
-    }
-  }
-}
-
 .missionTabPage {
   display: flex;
   flex-direction: column;

--- a/src/routes/user.routes.jsx
+++ b/src/routes/user.routes.jsx
@@ -9,13 +9,14 @@ import MyInfoPage from "../pages/User/MyInfoPage";
 import ShopPage from "../pages/shop/ShopPage";
 import ShopHistoryPage from "../pages/Shop/ShopHistoryPage";
 import AdminShopPage from "../pages/Shop/AdminShopPage";
+import MissionGroupPage from "../pages/Mission/MissionGroupPage";
 
 export default [
   {
     element: (
-        <MainLayout>
-          <Outlet />
-        </MainLayout>
+      <MainLayout>
+        <Outlet />
+      </MainLayout>
     ),
     children: [
       {
@@ -25,7 +26,7 @@ export default [
         // errorElement: <DashboardErrorPage />, // 에러 바운더리
       },
       {
-        path: "/missions",
+        path: "/mission",
         element: <MissionOverviewPage />,
       },
       {
@@ -43,19 +44,32 @@ export default [
       // { path: "/profile", element: <ProfilePage /> },
       {
         path: "/profile",
-        element: <MyInfoPage />
+        element: <MyInfoPage />,
       },
       {
         path: "/shop",
-        element: <ShopPage />
+        element: <ShopPage />,
       },
       {
         path: "/shopHistory",
-        element: <ShopHistoryPage />
+        element: <ShopHistoryPage />,
       },
       {
         path: "/adminShop",
-        element: <AdminShopPage />
+        element: <AdminShopPage />,
+      },
+      {
+        path: "/mission-group/:missionGroupId",
+        children: [
+          {
+            path: "home",
+            element: <MissionGroupPage componentType="home" />,
+          },
+          {
+            path: "learning-plan",
+            element: <MissionGroupPage componentType="learning-plan" />,
+          },
+        ],
       },
       // { path: "/settings", element: <SettingsPage /> },
       // ... 추가 사용자 경로


### PR DESCRIPTION
사이드바에 상점과 /shop을 연결했습니다.
사이드 바에 미션 그룹 목록이 나오고 그룹 이름에 따른 아이콘을 추가했습니다.
미션 그룹 홈에 멤버 목록을 추가하고 학습 계획에 칸반 보드를 구현하였습니다.

의존성에 @hello-pangea/dnd 가 추가되었으므로 npm i 한 번 실행하시기 바랍니다.

![image](https://github.com/user-attachments/assets/2fa87751-28b7-4afd-8362-d8b7d3db0a9b)
![image](https://github.com/user-attachments/assets/e0c552b9-0e10-4896-b411-41e1a8ce338d)
![image](https://github.com/user-attachments/assets/454ff4b3-860e-44ff-b872-64a0fa823623)

closes #34 