### PR TITLE
출석체크 api 연동

### DIFF
--- a/src/api/attendanceService.js
+++ b/src/api/attendanceService.js
@@ -1,0 +1,13 @@
+import api from "./axiosInstance";
+
+// 오늘 출석 현황 + 연속일수
+export const getAttendanceStatus = () =>
+  api.get("/api/v1/attendance/status");
+
+// 출석 체크
+export const checkAttendance = () =>
+  api.post("/api/v1/attendance/check");
+
+// 출석한 전체 날짜
+export const getAttendanceDates = () =>
+  api.get("/api/v1/attendance/dates");

--- a/src/components/Dashboard/AttendanceCheck.jsx
+++ b/src/components/Dashboard/AttendanceCheck.jsx
@@ -1,49 +1,117 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { getAttendanceStatus, checkAttendance } from "../../api/attendanceService";
+import { startOfWeek, addDays, format, parseISO } from "date-fns";
 import styles from "./AttendanceCheck.module.scss";
 
-function AttendanceCheck() {
-  // 출석 데이터 예시 (실제로는 props나 API에서 받아와야 함)
-  const attendanceData = [
-    { date: 8, isAttended: false },
-    { date: 9, isAttended: true },
-    { date: 10, isAttended: true },
-    { date: 11, isAttended: true },
-    { date: 12, isAttended: false },
-    { date: 13, isAttended: false },
-    { date: 14, isAttended: false },
-  ];
+export default function AttendanceCheck() {
+  // [{ weekday: 0~6, date: Date, isAttended: boolean }]
+  const [attendanceData, setAttendanceData] = useState([]);
+  const [consecutiveDays, setConsecutiveDays] = useState(0);
+  const [loading, setLoading] = useState(false);
 
-  const consecutiveDays = 0; // 연속 출석일수 (API에서 가져오는 값)
+  useEffect(() => {
+    async function fetchStatus() {
+      try {
+        const {
+          data: {
+            data: { attendanceStatus, continuousDay, today: todayStr }
+          }
+        } = await getAttendanceStatus();
+
+        setConsecutiveDays(continuousDay);
+
+        // 이번 주 일요일부터 토요일까지 날짜 배열 생성
+        const todayDate = parseISO(todayStr);
+        const weekStart = startOfWeek(todayDate, { weekStartsOn: 0 });
+        const week = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
+
+        // 날짜와 출석 여부 결합
+        const weekData = week.map((dateObj, idx) => ({
+          weekday: idx,
+          date: dateObj,
+          isAttended: attendanceStatus[idx] || false
+        }));
+        setAttendanceData(weekData);
+      } catch (error) {
+        console.error("출석 정보 로드 실패:", error);
+        alert("출석 정보 로드 중 오류가 발생했습니다.");
+      }
+    }
+    fetchStatus();
+  }, []);
+
+  const handleCheck = async () => {
+    if (loading) return;
+    setLoading(true);
+
+    try {
+      const {
+        data: {
+          data: { attend, exp, point }
+        }
+      } = await checkAttendance();
+
+      const todayIdx = new Date().getDay(); // 0=일요일,6=토요일
+      if (attend) {
+        setAttendanceData(prev =>
+          prev.map(item =>
+            item.weekday === todayIdx
+              ? { ...item, isAttended: true }
+              : item
+          )
+        );
+        setConsecutiveDays(prev => prev + 1);
+      }
+    } catch (error) {
+      console.error("출석 체크 실패:", error);
+      const status = error.response?.status;
+      if (status === 409) {
+        alert("이미 출석체크가 완료되었습니다.");
+      } else {
+        alert("출석 체크 중 오류가 발생했습니다.");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 오늘 index와 출석 여부
+  const todayIdx = new Date().getDay();
+  const hasAttendedToday = attendanceData[todayIdx]?.isAttended;
 
   return (
     <div className={styles.attendanceCheck}>
-      <div>
+      <div className={styles.header}>
         <h3>출석체크</h3>
         <span>연속 출석 {consecutiveDays}일</span>
       </div>
-      <table>
+
+      <table className={styles.calendar}>
         <thead>
           <tr>
-            <th>일</th>
-            <th>월</th>
-            <th>화</th>
-            <th>수</th>
-            <th>목</th>
-            <th>금</th>
-            <th>토</th>
+            {['일','월','화','수','목','금','토'].map((d, i) => (
+              <th key={i}>{d}</th>
+            ))}
           </tr>
         </thead>
         <tbody>
           <tr>
-            {attendanceData.map((day, index) => (
-              <td key={index}>{day.date}</td>
+            {attendanceData.map(({ weekday, date, isAttended }) => (
+              <td key={weekday} className={isAttended ? styles.attended : ''}>
+                {isAttended ? '✔︎' : format(date, 'd')}
+              </td>
             ))}
           </tr>
         </tbody>
       </table>
-      <button>출석체크하기</button>
+
+      <button
+        className={styles.checkButton}
+        onClick={handleCheck}
+        disabled={loading || hasAttendedToday}
+      >
+        {hasAttendedToday ? '내일 또 만나요' : loading ? '처리중...' : '출석체크하기'}
+      </button>
     </div>
   );
 }
-
-export default AttendanceCheck;

--- a/src/components/Dashboard/AttendanceCheck.module.scss
+++ b/src/components/Dashboard/AttendanceCheck.module.scss
@@ -65,4 +65,30 @@
       background-color: #3a7bbf;
     }
   }
+
+  .checkButton {
+  background-color: #409eff;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+
+  &:hover {
+    background-color: #66b1ff;
+  }
+
+  &:disabled {
+    /* 내일 또 만나요 / disabled 상태 */
+    background-color: #3a7bbf;
+    cursor: default; // 커서 모양 변하지 않게 고정
+  }
+
+  /* disabled 상태에서 hover도 무시 */
+  &:disabled:hover {
+    background-color: #3a7bbf;
+  }
+}
+
 }


### PR DESCRIPTION
- 출석체크 조회 api와 출석체크 api 연동 완료하였습니다.
- 이미 오늘 출석체크 했으면, "출석체크 하기" 버튼이 "내일 또 만나요" 버튼으로 변경되면서 상호작용이 불가능하게 막아두었습니다.

<img width="1624" alt="스크린샷 2025-06-30 오후 3 01 40" src="https://github.com/user-attachments/assets/c044d601-4a62-41df-8067-3a08a229b555" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 출석 현황 확인, 오늘 출석 체크, 출석한 날짜 목록 조회 기능이 추가되었습니다.
  * 출석 현황과 연속 출석 일수를 실시간으로 확인할 수 있습니다.
  * 오늘 출석 체크 시 버튼 상태와 안내 메시지가 상황에 따라 동적으로 변경됩니다.

* **스타일**
  * 출석 체크 버튼에 새로운 스타일이 적용되어, 상태(활성/비활성/호버)에 따라 시각적으로 구분됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->