### PR TITLE
Feature/#85 빌드 상태에 따라 base_url이 변하게 설정

### DIFF
--- a/src/api/baseUrl.js
+++ b/src/api/baseUrl.js
@@ -1,2 +1,2 @@
-const BASE_URL = "http://localhost:8080";
+const BASE_URL = __BASE_URL__;
 export default BASE_URL;

--- a/src/components/Mission/MissionItem.jsx
+++ b/src/components/Mission/MissionItem.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import styles from "./MissionItem.module.scss";
 import { FaCircleCheck, FaFlag } from "react-icons/fa6";
 import missionDifficultyMap from "../../utils/missionDifficultyMap";
+import useTokenPayload from "../../stores/tokenPayloadStore";
 
 function MissionItem({
   title,
@@ -15,6 +16,7 @@ function MissionItem({
   onMissionEditClick = () => {},
 }) {
   let classByState = null;
+  const tokenPayload = useTokenPayload((state) => state.tokenPayload);
 
   if (currentState) {
     classByState = "IN_PROGRESS";
@@ -45,16 +47,18 @@ function MissionItem({
           </span>
         )}
         <p>{title}</p>
-        <button
-          className={styles.editButton}
-          onClick={(e) => {
-            e.stopPropagation();
-            onMissionEditClick();
-          }}
-          aria-label={`${title} 미션 편집`}
-        >
-          Edit
-        </button>
+        {tokenPayload?.role === "ROLE_ADMIN" && (
+          <button
+            className={styles.editButton}
+            onClick={(e) => {
+              e.stopPropagation();
+              onMissionEditClick();
+            }}
+            aria-label={`${title} 미션 편집`}
+          >
+            Edit
+          </button>
+        )}
         <div style={{ display: "none" }}>
           <progress value={progressValue} max={maxProgress} />
           <span>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,22 +1,29 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   server: {
-    host: '0.0.0.0',
+    host: "0.0.0.0",
     port: 5173,
     watch: {
-      usePolling: true
+      usePolling: true,
     },
     hmr: {
-      clientPort: 5173
+      clientPort: 5173,
     },
     allowedHosts: [
-      'ec2-43-201-109-130.ap-northeast-2.compute.amazonaws.com',
-      'localhost',
-      '127.0.0.1'
-    ]
-  }
-})
+      "ec2-43-201-109-130.ap-northeast-2.compute.amazonaws.com",
+      "localhost",
+      "127.0.0.1",
+    ],
+  },
+  define: {
+    __BASE_URL__: JSON.stringify(
+      process.env.NODE_ENV === "production"
+        ? "https://api.hugexp.xyz"
+        : "http://localhost:8080"
+    ),
+  },
+});


### PR DESCRIPTION
개발 환경에서는
http://localhost:8080
배포 환경에서는
https://api.hugexp.xyz
으로 설정되도록 하였습니다.

주소는 vite.config.js에서 
```js
  define: {
    __BASE_URL__: JSON.stringify(
      process.env.NODE_ENV === "production"
        ? "https://api.hugexp.xyz"
        : "http://localhost:8080"
    ),
  },
```
부분을 통해 수정할 수 있습니다.

closes #85 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 환경에 따라 API 기본 URL이 자동으로 설정되도록 개선되었습니다. (프로덕션: https://api.hugexp.xyz, 개발: http://localhost:8080)
  * 내부 설정의 코드 스타일이 일관성 있게 정리되었습니다.
* **New Features**
  * 관리자 권한이 있는 사용자만 미션 항목에서 "수정" 버튼을 볼 수 있도록 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->