### PR TITLE
로그인 페이지 css까지 영향을 미치던 북마크 도메인 css 수정

### DIFF
--- a/src/components/Dashboard/BookmarkForm.jsx
+++ b/src/components/Dashboard/BookmarkForm.jsx
@@ -72,6 +72,7 @@ function BookmarkForm({ open, onClose, onSubmit, initialData }) {
             id="bookmark-url"
             type="url"
             value={link}
+            className={styles.urlInput}
             onChange={e => setLink(e.target.value)}
             placeholder="URL"
             required
@@ -82,6 +83,7 @@ function BookmarkForm({ open, onClose, onSubmit, initialData }) {
             id="bookmark-title"
             type="text"
             value={title}
+            className={styles.titleInput}
             onChange={e => setTitle(e.target.value)}
             placeholder="표시 텍스트"
           />

--- a/src/components/Dashboard/BookmarkForm.jsx
+++ b/src/components/Dashboard/BookmarkForm.jsx
@@ -83,7 +83,7 @@ function BookmarkForm({ open, onClose, onSubmit, initialData }) {
             id="bookmark-title"
             type="text"
             value={title}
-            className={styles.titleInput}
+            className={styles.textInput}
             onChange={e => setTitle(e.target.value)}
             placeholder="표시 텍스트"
           />

--- a/src/components/Dashboard/BookmarkForm.jsx
+++ b/src/components/Dashboard/BookmarkForm.jsx
@@ -63,35 +63,37 @@ function BookmarkForm({ open, onClose, onSubmit, initialData }) {
   if (!open) return null;
 
   return (
-    <div className={styles.modal}>
-      <div className={styles.modalContent} role="dialog" aria-labelledby="bookmark-form-title">
-        <h2 id="bookmark-form-title">{initialData ? '북마크 수정' : '북마크 추가'}</h2>
-        <form ref={formRef} onSubmit={handleSubmit}>
-          <label htmlFor="bookmark-url">URL</label>
-          <input
-            id="bookmark-url"
-            type="url"
-            value={link}
-            className={styles.urlInput}
-            onChange={e => setLink(e.target.value)}
-            placeholder="URL"
-            required
-            autoFocus
-          />
-          <label htmlFor="bookmark-title">표시 텍스트</label>
-          <input
-            id="bookmark-title"
-            type="text"
-            value={title}
-            className={styles.textInput}
-            onChange={e => setTitle(e.target.value)}
-            placeholder="표시 텍스트"
-          />
-          <div className={styles.modalActionRow}>
-            <button type="submit">{initialData ? "수정하기" : "추가하기"}</button>
-            <button type="button" onClick={onClose}>닫기</button>
-          </div>
-        </form>
+    <div className={styles.BookmarkForm}>
+      <div className={styles.modal}>
+        <div className={styles.modalContent} role="dialog" aria-labelledby="bookmark-form-title">
+          <h2 id="bookmark-form-title">{initialData ? '북마크 수정' : '북마크 추가'}</h2>
+          <form ref={formRef} onSubmit={handleSubmit}>
+            <label htmlFor="bookmark-url">URL</label>
+            <input
+              id="bookmark-url"
+              type="url"
+              value={link}
+              className={styles.urlInput}
+              onChange={e => setLink(e.target.value)}
+              placeholder="URL"
+              required
+              autoFocus
+            />
+            <label htmlFor="bookmark-title">표시 텍스트</label>
+            <input
+              id="bookmark-title"
+              type="text"
+              value={title}
+              className={styles.textInput}
+              onChange={e => setTitle(e.target.value)}
+              placeholder="표시 텍스트"
+            />
+            <div className={styles.modalActionRow}>
+              <button type="submit">{initialData ? "수정하기" : "추가하기"}</button>
+              <button type="button" onClick={onClose}>닫기</button>
+            </div>
+          </form>
+        </div>
       </div>
     </div>
   );

--- a/src/components/Dashboard/BookmarkForm.module.scss
+++ b/src/components/Dashboard/BookmarkForm.module.scss
@@ -41,24 +41,30 @@ label {
   margin-bottom: 4px;
 }
 
-input[type="url"], input[type="text"] {
+.urlInput {
   width: 100%;
   font-size: 16px;
-  padding: 9px 13px;
-  border-radius: 7px;
-  border: 1.2px solid #e4e8f1;
-  background: #f6f8fb;
-  color: #20262d;
+  padding: 8px 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  margin-bottom: 12px;
+}
+.urlInput:focus {
   outline: none;
-  margin-bottom: 5px;
-  box-sizing: border-box;
-  transition: border 0.14s;
+  border-color: #007bff;
 }
 
-input[type="url"]:focus,
-input[type="text"]:focus {
-  border: 1.5px solid #3b82f6;
-  background: #f1f8ff;
+.textInput {
+  width: 100%;
+  font-size: 16px;
+  padding: 8px 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  margin-bottom: 12px;
+}
+.textInput:focus {
+  outline: none;
+  border-color: #007bff;
 }
 
 button[type="submit"] {

--- a/src/components/Dashboard/BookmarkForm.module.scss
+++ b/src/components/Dashboard/BookmarkForm.module.scss
@@ -1,117 +1,119 @@
-.modal {
-  position: fixed;
-  left: 0; top: 0;
-  width: 100vw; height: 100vh;
-  background: rgba(0,0,0,0.20);
-  z-index: 2000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
+.BookmarkForm {
+  .modal {
+    position: fixed;
+    left: 0; top: 0;
+    width: 100vw; height: 100vh;
+    background: rgba(0,0,0,0.20);
+    z-index: 2000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
 
-.modalContent {
-  background: #fff;
-  color: #1b2340;
-  padding: 32px 28px 22px 28px;
-  border-radius: 14px;
-  min-width: 330px;
-  max-width: 94vw;
-  box-shadow: 0 8px 40px rgba(0,0,0,0.16);
-  display: flex;
-  flex-direction: column;
-}
-
-h2 {
-  font-size: 20px;
-  font-weight: 700;
-  margin: 0 0 18px 0;
-  color: #22314d;
-}
-
-form {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-label {
-  color: #22314d;
-  font-weight: 500;
-  font-size: 14px;
-  margin-bottom: 4px;
-}
-
-.urlInput {
-  width: 100%;
-  font-size: 16px;
-  padding: 8px 12px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  margin-bottom: 12px;
-}
-.urlInput:focus {
-  outline: none;
-  border-color: #007bff;
-}
-
-.textInput {
-  width: 100%;
-  font-size: 16px;
-  padding: 8px 12px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  margin-bottom: 12px;
-}
-.textInput:focus {
-  outline: none;
-  border-color: #007bff;
-}
-
-button[type="submit"] {
-  background: #2563eb;
-  color: #fff;
-  border: none;
-  border-radius: 7px;
-  font-weight: 600;
-  font-size: 16px;
-  padding: 8px 18px;
-  margin-right: 7px;
-  cursor: pointer;
-  transition: background 0.14s;
-}
-
-button[type="submit"]:hover {
-  background: #1859db;
-}
-
-button[type="button"] {
-  background: #f1f3fa;
-  color: #222;
-  border: none;
-  border-radius: 7px;
-  font-weight: 600;
-  font-size: 16px;
-  padding: 8px 18px;
-  cursor: pointer;
-  margin-left: 4px;
-  transition: background 0.12s;
-}
-
-button[type="button"]:hover {
-  background: #e6e9f4;
-}
-
-.modalActionRow {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-  margin-top: 14px;
-}
-
-@media (max-width: 600px) {
   .modalContent {
-    min-width: 0;
-    width: 98vw;
-    padding: 18px 8px 16px 8px;
+    background: #fff;
+    color: #1b2340;
+    padding: 32px 28px 22px 28px;
+    border-radius: 14px;
+    min-width: 330px;
+    max-width: 94vw;
+    box-shadow: 0 8px 40px rgba(0,0,0,0.16);
+    display: flex;
+    flex-direction: column;
+  }
+
+  h2 {
+    font-size: 20px;
+    font-weight: 700;
+    margin: 0 0 18px 0;
+    color: #22314d;
+  }
+
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  label {
+    color: #22314d;
+    font-weight: 500;
+    font-size: 14px;
+    margin-bottom: 4px;
+  }
+
+  .urlInput {
+    width: 100%;
+    font-size: 16px;
+    padding: 8px 12px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    margin-bottom: 12px;
+  }
+  .urlInput:focus {
+    outline: none;
+    border-color: #007bff;
+  }
+
+  .textInput {
+    width: 100%;
+    font-size: 16px;
+    padding: 8px 12px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    margin-bottom: 12px;
+  }
+  .textInput:focus {
+    outline: none;
+    border-color: #007bff;
+  }
+
+  button[type="submit"] {
+    background: #2563eb;
+    color: #fff;
+    border: none;
+    border-radius: 7px;
+    font-weight: 600;
+    font-size: 16px;
+    padding: 8px 18px;
+    margin-right: 7px;
+    cursor: pointer;
+    transition: background 0.14s;
+  }
+
+  button[type="submit"]:hover {
+    background: #1859db;
+  }
+
+  button[type="button"] {
+    background: #f1f3fa;
+    color: #222;
+    border: none;
+    border-radius: 7px;
+    font-weight: 600;
+    font-size: 16px;
+    padding: 8px 18px;
+    cursor: pointer;
+    margin-left: 4px;
+    transition: background 0.12s;
+  }
+
+  button[type="button"]:hover {
+    background: #e6e9f4;
+  }
+
+  .modalActionRow {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 14px;
+  }
+
+  @media (max-width: 600px) {
+    .modalContent {
+      min-width: 0;
+      width: 98vw;
+      padding: 18px 8px 16px 8px;
+    }
   }
 }

--- a/src/components/Dashboard/BookmarkSection.jsx
+++ b/src/components/Dashboard/BookmarkSection.jsx
@@ -132,7 +132,8 @@ function BookmarkSection() {
   };
 
   return (
-    <section className={styles.section}>
+    <div className={styles.BookmarkSection}>
+      <section className={styles.section}>
       {/* 툴바 */}
       <div className={styles.toolbar}>
         <button className={styles.addBtn} onClick={openAddModal}>
@@ -203,10 +204,12 @@ function BookmarkSection() {
         <div className={styles.modalBackdrop} onClick={closeModal}>
             <div className={styles.modalCard} onClick={e => e.stopPropagation()}>
             <form ref={formRef} onSubmit={handleSubmit}>
-                <label>
+                <label htmlFor="bookmark-url" className={styles.label}>
                 URL
                 <input
+                    id="bookmark-url"
                     type="url"
+                    className={styles.input}
                     value={link}
                     required
                     onChange={(e) => setLink(e.target.value)}
@@ -214,24 +217,40 @@ function BookmarkSection() {
                     autoFocus
                 />
                 </label>
-                <label>
-                표시 텍스트 (선택)
+                <label htmlFor="bookmark-title" className={styles.label}>
+                표시할 텍스트 (선택)
                 <input
+                    id="bookmark-title"
                     type="text"
+                    className={styles.input}
                     value={title}
                     onChange={(e) => setTitle(e.target.value)}
-                    placeholder="링크를 나타낼 텍스트를 작성"
+                    placeholder="링크를 나타낼 텍스트를 작성해주세요"
                 />
                 </label>
                 <div>
-                <button type="button" onClick={closeModal}>닫기</button>
-                <button type="submit">{editItem ? "수정하기" : "추가하기"}</button>
+                <div className={styles.modalActionRow}>
+                  <button
+                    type="button"
+                    className={styles.modalCancelBtn}
+                    onClick={closeModal}
+                  >
+                    닫기
+                  </button>
+                  <button
+                    type="submit"
+                    className={styles.modalOkBtn}
+                  >
+                    {editItem ? "수정하기" : "추가하기"}
+                  </button>
+                </div>
                 </div>
             </form>
-            </div>
+          </div>
         </div>
         )}
-    </section>
+     </section>    
+    </div>
   );
 }
 

--- a/src/components/Dashboard/BookmarkSection.module.scss
+++ b/src/components/Dashboard/BookmarkSection.module.scss
@@ -1,156 +1,158 @@
-.section {
-  margin: 2rem 0;
-}
+.BookmarkSection {
+  .section {
+    margin: 2rem 0;
+  }
 
-.toolbar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 16px;
-}
+  .toolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 16px;
+  }
 
-.addBtn {
-  background: #2563eb;
-  color: #fff;
-  padding: 7px 18px;
-  border: none;
-  border-radius: 8px;
-  font-weight: 600;
-  font-size: 15px;
-  cursor: pointer;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.11);
-}
+  .addBtn {
+    background: #2563eb;
+    color: #fff;
+    padding: 7px 18px;
+    border: none;
+    border-radius: 8px;
+    font-weight: 600;
+    font-size: 15px;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.11);
+  }
 
-.chipList {
-  display: flex;
-  gap: 8px;
-  overflow-x: auto;
-  padding: 3px 0;
-  scrollbar-width: none;
-  ms-overflow-style: none;
-  flex: 1;
-}
+  .chipList {
+    display: flex;
+    gap: 8px;
+    overflow-x: auto;
+    padding: 3px 0;
+    scrollbar-width: none;
+    ms-overflow-style: none;
+    flex: 1;
+  }
 
-.chip {
-  display: inline-flex;
-  align-items: center;
-  background: #fff;
-  color: #2563eb;
-  border: 1.5px solid #d5e2fb;
-  border-radius: 20px;
-  padding: 6px 18px;
-  min-height: 32px;
-  min-width: 40px;
-  max-width: 200px;
-  font-weight: 500;
-  font-size: 15px;
-  box-shadow: 0 2px 10px rgba(55,109,223,0.07);
-  cursor: pointer;
-  transition: border 0.15s, box-shadow 0.15s, background 0.14s;
-  margin-right: 2px;
-  outline: none;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    background: #fff;
+    color: #2563eb;
+    border: 1.5px solid #d5e2fb;
+    border-radius: 20px;
+    padding: 6px 18px;
+    min-height: 32px;
+    min-width: 40px;
+    max-width: 200px;
+    font-weight: 500;
+    font-size: 15px;
+    box-shadow: 0 2px 10px rgba(55,109,223,0.07);
+    cursor: pointer;
+    transition: border 0.15s, box-shadow 0.15s, background 0.14s;
+    margin-right: 2px;
+    outline: none;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 
-.chipLink {
-  color: #2563eb;
-  text-decoration: none;
-  font-weight: 500;
-  font-size: 15px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: 140px;
-  display: block;
-}
+  .chipLink {
+    color: #2563eb;
+    text-decoration: none;
+    font-weight: 500;
+    font-size: 15px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 140px;
+    display: block;
+  }
 
-.contextMenu {
-  position: fixed;
-  background: #fff;
-  border: 1px solid #eee;
-  border-radius: 10px;
-  box-shadow: 0 2px 16px rgba(0,0,0,0.16);
-  min-width: 110px;
-  z-index: 2000;
-  padding: 4px 0;
-  margin-top: 4px;
-}
+  .contextMenu {
+    position: fixed;
+    background: #fff;
+    border: 1px solid #eee;
+    border-radius: 10px;
+    box-shadow: 0 2px 16px rgba(0,0,0,0.16);
+    min-width: 110px;
+    z-index: 2000;
+    padding: 4px 0;
+    margin-top: 4px;
+  }
 
-.menuItem {
-  padding: 10px 18px;
-  cursor: pointer;
-  font-size: 15px;
-  color: #333;
-  transition: background 0.14s;
-  border: none;
-  background: none;
-}
+  .menuItem {
+    padding: 10px 18px;
+    cursor: pointer;
+    font-size: 15px;
+    color: #333;
+    transition: background 0.14s;
+    border: none;
+    background: none;
+  }
 
-.modalBackdrop {
-  position: fixed;
-  left: 0; top: 0; width: 100vw; height: 100vh;
-  background: rgba(0,0,0,0.18);
-  display: flex; align-items: center; justify-content: center;
-  z-index: 9999;
-}
+  .modalBackdrop {
+    position: fixed;
+    left: 0; top: 0; width: 100vw; height: 100vh;
+    background: rgba(0,0,0,0.18);
+    display: flex; align-items: center; justify-content: center;
+    z-index: 9999;
+  }
 
-.modalCard {
-  background: #fff;
-  color: #222;
-  padding: 28px;
-  border-radius: 16px;
-  min-width: 340px;
-  box-shadow: 0 8px 36px rgba(0,0,0,0.14);
-}
+  .modalCard {
+    background: #fff;
+    color: #222;
+    padding: 28px;
+    border-radius: 16px;
+    min-width: 340px;
+    box-shadow: 0 8px 36px rgba(0,0,0,0.14);
+  }
 
-.label {
-  display: block;
-  color: #22314d;
-  font-weight: 500;
-  font-size: 13px;
-  margin-bottom: 5px;
-}
+  .label {
+    display: block;
+    color: #22314d;
+    font-weight: 500;
+    font-size: 13px;
+    margin-bottom: 5px;
+  }
 
-.input {
-  width: 100%;
-  padding: 8px 12px;
-  border-radius: 7px;
-  border: 1.3px solid #e4e8f1;
-  background: #f6f8fb;
-  color: #20262d;
-  font-size: 16px;
-  margin-top: 3px;
-  outline: none;
-  box-sizing: border-box;
-}
+  .input {
+    width: 100%;
+    padding: 8px 12px;
+    border-radius: 7px;
+    border: 1.3px solid #e4e8f1;
+    background: #f6f8fb;
+    color: #20262d;
+    font-size: 16px;
+    margin-top: 3px;
+    outline: none;
+    box-sizing: border-box;
+  }
 
-.modalActionRow {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-  margin-top: 18px;
-}
+  .modalActionRow {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 18px;
+  }
 
-.modalCancelBtn {
-  background: #f1f3fa;
-  color: #222;
-  border: none;
-  border-radius: 7px;
-  font-weight: 600;
-  font-size: 16px;
-  padding: 8px 18px;
-  cursor: pointer;
-}
+  .modalCancelBtn {
+    background: #f1f3fa;
+    color: #222;
+    border: none;
+    border-radius: 7px;
+    font-weight: 600;
+    font-size: 16px;
+    padding: 8px 18px;
+    cursor: pointer;
+  }
 
-.modalOkBtn {
-  background: #2563eb;
-  color: #fff;
-  border: none;
-  border-radius: 7px;
-  font-weight: 600;
-  font-size: 16px;
-  padding: 8px 18px;
-  cursor: pointer;
+  .modalOkBtn {
+    background: #2563eb;
+    color: #fff;
+    border: none;
+    border-radius: 7px;
+    font-weight: 600;
+    font-size: 16px;
+    padding: 8px 18px;
+    cursor: pointer;
+  }
 }


### PR DESCRIPTION
- bookmarkForm.module.scss 파일에서 input[type="text"]와 input[type="url"] 전역 선택자를 클래스 기반으로 변경
- bookmark와 관련된 css들을 각각의 파일명에 맞게 최상단을 감싸 중첩 처리하여, 전역 css가 되지 않게 설정
<img width="1624" alt="스크린샷 2025-07-08 오후 4 05 28" src="https://github.com/user-attachments/assets/8f431fc7-9d35-4929-b319-eeda0e7ee881" />
<img width="1624" alt="스크린샷 2025-07-08 오후 4 05 31" src="https://github.com/user-attachments/assets/8f8f821b-8035-4db8-8b34-6840f33adb7c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 북마크 폼과 섹션의 스타일이 개선되어 입력 필드 및 버튼의 시각적 일관성이 향상되었습니다.
  * 입력 필드에 새로운 스타일이 적용되고, 폼 전체가 더 깔끔하게 정돈되었습니다.

* **접근성**
  * 라벨과 입력 필드가 연결되어 폼 사용 시 접근성이 개선되었습니다.

* **기타**
  * 버튼 및 폼 레이아웃이 더 명확하게 구분되어 사용성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->