### PR TITLE
Feature/#101 유저 랭킹에 참여중인 미션 그룹 표시

### DIFF
--- a/src/pages/user/RankingPage.jsx
+++ b/src/pages/user/RankingPage.jsx
@@ -23,12 +23,12 @@ const RankingPage = () => {
 
   // 사용자별 미션 그룹 정보를 표시하는 함수
   const getUserMissionGroupsText = (user) => {
-    // user 객체에서 userMission 정보를 찾기
-    if (user.userMissions && user.userMissions.length > 0) {
-      const missionNames = user.userMissions
-        .map((userMission) => userMission.mission?.name)
+    // user 객체에서 missionGroups 정보를 찾기
+    if (user.missionGroups && user.missionGroups.length > 0) {
+      const missionNames = user.missionGroups
+        .map((missionGroup) => missionGroup.name)
         .filter(Boolean) // null/undefined 제거
-        .join(", ");
+        .join(" | ");
       return missionNames || "참여 중인 미션이 없습니다";
     }
 


### PR DESCRIPTION
<img width="1638" height="1083" alt="image" src="https://github.com/user-attachments/assets/41e86242-1dd7-4c5f-93b8-880f93fcedbd" />
다만 아직 현재 사용자는 나오지 않습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 미션 그룹 정보 표시 방식이 개선되어, 사용자 미션 그룹이 올바르게 표시됩니다. 미션 그룹 이름이 이제 세로 막대(" | ")로 구분되어 보여집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->