### PR TITLE
관리자 도메인 css 추가

### DIFF
--- a/src/components/Admin/AdminButton.jsx
+++ b/src/components/Admin/AdminButton.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import styles from './AdminButton.module.scss';
+
+export default function AdminButton() {
+  return (
+    <div className={styles.AdminButton}>
+      <Link to="/admin" className={styles.button}>
+        <span className={styles.icon}>⚙️</span>
+        관리자 페이지
+      </Link>
+    </div>
+  );
+}

--- a/src/components/Admin/AdminButton.module.scss
+++ b/src/components/Admin/AdminButton.module.scss
@@ -1,0 +1,27 @@
+.AdminButton {
+  display: flex;
+  justify-content: flex-start;
+  margin-bottom: 20px;
+
+  .button {
+    display: inline-flex;
+    align-items: center;
+    padding: 10px 16px;
+    background-color: #3b82f6;
+    color: white;
+    text-decoration: none;
+    border-radius: 6px;
+    font-size: 14px;
+    font-weight: 500;
+    transition: background-color 0.2s;
+    
+    &:hover {
+      background-color: #2563eb;
+    }
+  }
+
+  .icon {
+    margin-right: 6px;
+    font-size: 14px;
+  }
+}

--- a/src/components/Admin/UserTable.jsx
+++ b/src/components/Admin/UserTable.jsx
@@ -32,7 +32,7 @@ export default function UserTable({ users }) {
             <th>프로필</th>
             <th>ID</th>
             <th>이름</th>
-            <th>이메일</th>
+            <th>아이디</th>
             <th>권한</th>
             <th>액션</th>
           </tr>
@@ -49,7 +49,7 @@ export default function UserTable({ users }) {
               </td>
               <td>{user.id}</td>
               <td>{user.name || user.username}</td>
-              <td>{user.email || '이메일 없음'}</td>
+              <td>{user.username || '아이디 없음'}</td>
               <td>
                 <span className={getRoleBadgeClass(user.role)}>
                   {user.role}

--- a/src/components/Admin/UserTable.jsx
+++ b/src/components/Admin/UserTable.jsx
@@ -1,58 +1,64 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import defaultProfileIcon from '../../assets/images/user/empty-user-profile.svg';
+import styles from './UserTable.module.scss';
 
 export default function UserTable({ users }) {
   // users가 배열이 아니면 로딩 메시지나 빈 상태 표시
   if (!Array.isArray(users)) {
-    return <p>회원 목록을 불러오는 중입니다…</p>;
+    return <p className={styles.loadingMessage}>회원 목록을 불러오는 중입니다…</p>;
   }
 
   if (users.length === 0) {
-    return <p>회원이 없습니다.</p>;
+    return <p className={styles.emptyMessage}>회원이 없습니다.</p>;
   }
 
+  const getRoleBadgeClass = (role) => {
+    switch (role) {
+      case 'ADMIN':
+        return `${styles.roleBadge} ${styles.admin}`;
+      case 'LECTURER':
+        return `${styles.roleBadge} ${styles.lecturer}`;
+      default:
+        return `${styles.roleBadge} ${styles.user}`;
+    }
+  };
+
   return (
-    <div className="overflow-x-auto">
-      <table className="min-w-full bg-white border border-gray-300">
+    <div className={styles.UserTable}>
+      <table>
         <thead>
-          <tr className="bg-gray-100">
-            <th className="px-4 py-2 text-left">프로필</th>
-            <th className="px-4 py-2 text-left">ID</th>
-            <th className="px-4 py-2 text-left">이름</th>
-            <th className="px-4 py-2 text-left">이메일</th>
-            <th className="px-4 py-2 text-left">권한</th>
-            <th className="px-4 py-2 text-left">액션</th>
+          <tr>
+            <th>프로필</th>
+            <th>ID</th>
+            <th>이름</th>
+            <th>이메일</th>
+            <th>권한</th>
+            <th>액션</th>
           </tr>
         </thead>
         <tbody>
           {users.map((user) => (
-            <tr key={user.id} className="border-b hover:bg-gray-50">
-              <td className="px-4 py-2">
-                <div className="flex items-center">
-                  <img
-                    src={user.profileImage || defaultProfileIcon}
-                    alt={`${user.username} 프로필`}
-                    className="w-10 h-10 rounded-full object-cover"
-                  />
-                </div>
+            <tr key={user.id}>
+              <td>
+                <img
+                  src={user.profileImage || defaultProfileIcon}
+                  alt={`${user.username} 프로필`}
+                  className={styles.profileImage}
+                />
               </td>
-              <td className="px-4 py-2">{user.id}</td>
-              <td className="px-4 py-2">{user.name || user.username}</td>
-              <td className="px-4 py-2">{user.email || '이메일 없음'}</td>
-              <td className="px-4 py-2">
-                <span className={`px-2 py-1 rounded text-xs ${
-                  user.role === 'ADMIN' ? 'bg-red-100 text-red-800' :
-                  user.role === 'LECTURER' ? 'bg-blue-100 text-blue-800' :
-                  'bg-green-100 text-green-800'
-                }`}>
+              <td>{user.id}</td>
+              <td>{user.name || user.username}</td>
+              <td>{user.email || '이메일 없음'}</td>
+              <td>
+                <span className={getRoleBadgeClass(user.role)}>
                   {user.role}
                 </span>
               </td>
-              <td className="px-4 py-2">
+              <td>
                 <Link
                   to={`/admin/users/${user.username}`}
-                  className="text-blue-500 hover:text-blue-700"
+                  className={styles.actionLink}
                 >
                   상세보기
                 </Link>

--- a/src/components/Admin/UserTable.module.scss
+++ b/src/components/Admin/UserTable.module.scss
@@ -1,0 +1,98 @@
+.UserTable {
+  overflow-x: auto;
+  border-radius: 8px;
+  border: 1px solid #e0e0e0;
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    background-color: white;
+    font-size: 14px;
+
+    thead {
+      tr {
+        background-color: #f8fafc;
+        
+        th {
+          padding: 12px 16px;
+          text-align: left;
+          color: #374151;
+          font-weight: 600;
+          font-size: 13px;
+          text-transform: uppercase;
+          letter-spacing: 0.025em;
+        }
+      }
+    }
+
+    tbody {
+      tr {
+        border-bottom: 1px solid #e0e0e0;
+        transition: background-color 0.2s;
+        
+        &:hover {
+          background-color: #f9fafb;
+        }
+
+        td {
+          padding: 12px 16px;
+          color: #6b7280;
+        }
+      }
+    }
+  }
+
+  .profileImage {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    object-fit: cover;
+  }
+
+  .roleBadge {
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: 500;
+    
+    &.admin {
+      background-color: #fef2f2;
+      color: #dc2626;
+    }
+    
+    &.lecturer {
+      background-color: #eff6ff;
+      color: #2563eb;
+    }
+    
+    &.user {
+      background-color: #f0fdf4;
+      color: #16a34a;
+    }
+  }
+
+  .actionLink {
+    color: #3b82f6;
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.2s;
+    
+    &:hover {
+      color: #2563eb;
+    }
+  }
+
+  .loadingMessage {
+    text-align: center;
+    padding: 40px;
+    color: #6b7280;
+    font-size: 16px;
+  }
+
+  .emptyMessage {
+    text-align: center;
+    padding: 40px;
+    color: #6b7280;
+    font-size: 16px;
+  }
+}

--- a/src/components/Admin/UserTable.module.scss
+++ b/src/components/Admin/UserTable.module.scss
@@ -56,18 +56,18 @@
     font-weight: 500;
     
     &.admin {
-      background-color: #fef2f2;
-      color: #dc2626;
+      background-color: #fef3c7;  
+      color: #d97706;           
     }
     
     &.lecturer {
-      background-color: #eff6ff;
-      color: #2563eb;
+      background-color: #e0e7ff;  
+      color: #6366f1;           
     }
     
     &.user {
-      background-color: #f0fdf4;
-      color: #16a34a;
+      background-color: #f3f4f6;  
+      color: #6b7280;           
     }
   }
 

--- a/src/layouts/AdminLayout.jsx
+++ b/src/layouts/AdminLayout.jsx
@@ -29,10 +29,14 @@ export default function AdminLayout() {
         setUserInfo(data);
       } catch (error) {
         console.error("Error fetching user data:", error);
+        if (error.response?.status === 401) {
+          localStorage.clear();
+          navigate("/login", { replace: true });
+        }
       }
     };
     fetchUserData();
-  }, [setUserInfo]);
+  }, [setUserInfo, navigate]);
 
   useEffect(() => {
     if (!localStorage.getItem("accessToken")) {

--- a/src/layouts/AdminLayout.jsx
+++ b/src/layouts/AdminLayout.jsx
@@ -17,8 +17,20 @@ export default function AdminLayout() {
   useEffect(() => {
     const token = localStorage.getItem("accessToken");
     if (token) {
-      const payload = jwtDecode(token);
-      setTokenPayload(payload);
+      try {
+        const payload = jwtDecode(token);
+        // 토큰 만료 체크
+        if (payload.exp && payload.exp * 1000 < Date.now()) {
+          localStorage.clear();
+          navigate("/login", { replace: true });
+          return;
+        }
+        setTokenPayload(payload);
+      } catch (error) {
+        console.error("Invalid token:", error);
+        localStorage.clear();
+        navigate("/login", { replace: true });
+      }
     }
   }, [setTokenPayload]);
 

--- a/src/layouts/AdminLayout.module.scss
+++ b/src/layouts/AdminLayout.module.scss
@@ -57,7 +57,12 @@
     &:hover {
       background-color: #f1f5f9;
     }
-    
+
+    &:focus-visible {
+      outline: 2px solid #3b82f6;
+      outline-offset: 2px;
+    }
+
     &.active {
       background-color: #e2e8f0;
       color: #1e293b;
@@ -107,33 +112,5 @@
     height: 100vh;
     font-size: 16px;
     color: #6b7280;
-  }
-
-  .AdminButton {
-    display: flex;
-    justify-content: flex-start; // flex-end → flex-start로 변경
-    margin-bottom: 20px;
-
-    .button {
-      display: inline-flex;
-      align-items: center;
-      padding: 10px 16px;
-      background-color: #3b82f6;
-      color: white;
-      text-decoration: none;
-      border-radius: 6px;
-      font-size: 14px;
-      font-weight: 500;
-      transition: background-color 0.2s;
-      
-      &:hover {
-        background-color: #2563eb;
-      }
-    }
-
-    .icon {
-      margin-right: 6px;
-      font-size: 14px;
-    }
   }
 }

--- a/src/layouts/AdminLayout.module.scss
+++ b/src/layouts/AdminLayout.module.scss
@@ -1,0 +1,139 @@
+.AdminLayout {
+  display: flex;
+  flex-direction: row;
+  min-height: 100vh;
+  width: 100%;
+
+  .sidebar {
+    width: 250px;
+    background-color: #f8fafc;
+    border-right: 1px solid #e2e8f0;
+    padding: 20px;
+  }
+
+  .sidebarHeader {
+    margin-bottom: 2rem;
+  }
+
+  .logo {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    color: #1e293b;
+  }
+
+  .adminInfo {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .adminName {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #1e293b;
+  }
+
+  .adminRole {
+    font-size: 0.875rem;
+    color: #94a3b8;
+  }
+
+  .nav {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .navItem {
+    display: flex;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    text-decoration: none;
+    border-radius: 4px;
+    transition: background-color 0.2s;
+    color: #374151;
+    
+    &:hover {
+      background-color: #f1f5f9;
+    }
+    
+    &.active {
+      background-color: #e2e8f0;
+      color: #1e293b;
+      font-weight: 600;
+    }
+  }
+
+  .navIcon {
+    margin-right: 0.5rem;
+    font-size: 1.2rem;
+  }
+
+  .content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .contentHeader {
+    background: white;
+    padding: 1rem 2rem;
+    border-bottom: 1px solid #e2e8f0;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  }
+
+  .breadcrumb {
+    font-size: 0.875rem;
+    color: #64748b;
+    
+    span:first-child {
+      font-weight: 600;
+      color: #3b82f6;
+    }
+  }
+
+  .main {
+    flex: 1;
+    overflow-y: auto;
+    background-color: #f8fafc;
+  }
+
+  .loadingMessage {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    font-size: 16px;
+    color: #6b7280;
+  }
+
+  .AdminButton {
+    display: flex;
+    justify-content: flex-start; // flex-end → flex-start로 변경
+    margin-bottom: 20px;
+
+    .button {
+      display: inline-flex;
+      align-items: center;
+      padding: 10px 16px;
+      background-color: #3b82f6;
+      color: white;
+      text-decoration: none;
+      border-radius: 6px;
+      font-size: 14px;
+      font-weight: 500;
+      transition: background-color 0.2s;
+      
+      &:hover {
+        background-color: #2563eb;
+      }
+    }
+
+    .icon {
+      margin-right: 6px;
+      font-size: 14px;
+    }
+  }
+}

--- a/src/pages/admin/AdminUserDetail.jsx
+++ b/src/pages/admin/AdminUserDetail.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { getUser, updateUser, deleteUser, changeUserRole } from '../../api/adminService';
+import styles from './AdminUserDetail.module.scss';
 
 export default function AdminUserDetail() {
   const { username } = useParams();
@@ -124,116 +125,118 @@ export default function AdminUserDetail() {
   };
 
   return (
-    <div>
-      <h2 className="text-xl font-semibold mb-4">회원 상세 정보</h2>
+    <div className={styles.AdminUserDetail}>
+      <h2 className={styles.title}>회원 상세 정보</h2>
       {user ? (
-        <div className="space-y-4">
-          <div>
-            <span className="font-medium block mb-1">아이디: </span> 
-            <span className="text-sm">{user.username}</span>
-          </div>
-          <div>
-            <label className="block mb-1">이름</label>
-            <input
-              type="text"
-              name="name"
-              value={form.name}
-              onChange={handleChange}
-              className="w-full border px-3 py-2 rounded"
-            />
-          </div>
-          <div>
-            <label className="block mb-1">설명</label>
-            <textarea
-              name="description"
-              value={form.description}
-              onChange={handleChange}
-              className="w-full border px-3 py-2 rounded"
-              rows="3"
-            />
-          </div>
-          <div>
-            <label className="block mb-1">전화번호</label>
-            <input
-              type="text"
-              name="phoneNumber"
-              value={form.phoneNumber}
-              onChange={handleChange}
-              placeholder="010-0000-0000"
-              className="w-full border px-3 py-2 rounded"
-            />
-          </div>
-          <div>
-            <label className="block mb-1">권한</label>
-            <select
-              name="role"
-              value={form.role}
-              onChange={handleRoleChange}
-              className="w-full border px-3 py-2 rounded"
-            >
-              <option value="USER">USER</option>
-              <option value="LECTURER">LECTURER</option> 
-              <option value="ADMIN">ADMIN</option>
-            </select>
-          </div>
-          
-          <div className="bg-gray-50 p-4 rounded">
-            <h3 className="font-semibold mb-2">수치 정보</h3>
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <span className="font-medium block mb-1">레벨:</span>
-                <span className="text-sm">{user.level}</span>
-              </div>
-              <div>
-                <span className="font-medium block mb-1">현재 총 경험치:</span>
-                <span className="text-sm">{user.currentTotalExp}</span>
-              </div>
-              <div>
-                <span className="font-medium block mb-1">다음 레벨 경험치:</span>
-                <span className="text-sm">{user.nextLevelTotalExp}</span>
-              </div>
-              <div>
-                <label className="font-medium block mb-1">경험치 (강제 리셋):</label>
-                <input
-                  type="number"
-                  name="exp"
-                  value={form.exp}
-                  onChange={handleChange}
-                  className="w-full border px-2 py-1 rounded text-sm"
-                  min="0"
-                />
-              </div>
-              <div>
-                <label className="font-medium block mb-1">포인트 (강제 리셋):</label>
-                <input
-                  type="number"
-                  name="point"
-                  value={form.point}
-                  onChange={handleChange}
-                  className="w-full border px-2 py-1 rounded text-sm"
-                  min="0"
-                />
+        <div className={styles.content}>
+          <div className={styles.card}>
+            <div className={styles.readOnlyField}>
+              <span className={styles.readOnlyLabel}>아이디:</span>
+              <span className={styles.readOnlyValue}>{user.username}</span>
+            </div>
+            
+            <div className={styles.formGroup}>
+              <label>이름</label>
+              <input
+                type="text"
+                name="name"
+                value={form.name}
+                onChange={handleChange}
+              />
+            </div>
+            
+            <div className={styles.formGroup}>
+              <label>설명</label>
+              <textarea
+                name="description"
+                value={form.description}
+                onChange={handleChange}
+                rows="3"
+              />
+            </div>
+            
+            <div className={styles.formGroup}>
+              <label>전화번호</label>
+              <input
+                type="text"
+                name="phoneNumber"
+                value={form.phoneNumber}
+                onChange={handleChange}
+                placeholder="010-0000-0000"
+              />
+            </div>
+            
+            <div className={styles.formGroup}>
+              <label>권한</label>
+              <select
+                name="role"
+                value={form.role}
+                onChange={handleRoleChange}
+              >
+                <option value="USER">USER</option>
+                <option value="LECTURER">LECTURER</option> 
+                <option value="ADMIN">ADMIN</option>
+              </select>
+            </div>
+            
+            <div className={styles.numericInfo}>
+              <h3>수치 정보</h3>
+              <div className={styles.numericFields}>
+                <div>
+                  <span className={styles.fieldLabel}>레벨:</span>
+                  <span className={styles.fieldValue}>{user.level}</span>
+                </div>
+                <div>
+                  <span className={styles.fieldLabel}>현재 총 경험치:</span>
+                  <span className={styles.fieldValue}>{user.currentTotalExp}</span>
+                </div>
+                <div>
+                  <span className={styles.fieldLabel}>다음 레벨 경험치:</span>
+                  <span className={styles.fieldValue}>{user.nextLevelTotalExp}</span>
+                </div>
+                <div>
+                  <label className={styles.fieldLabel}>경험치 (강제 리셋):</label>
+                  <input
+                    type="number"
+                    name="exp"
+                    value={form.exp}
+                    onChange={handleChange}
+                    className={styles.numberInput}
+                    min="0"
+                  />
+                </div>
+                <div>
+                  <label className={styles.fieldLabel}>포인트 (강제 리셋):</label>
+                  <input
+                    type="number"
+                    name="point"
+                    value={form.point}
+                    onChange={handleChange}
+                    className={styles.numberInput}
+                    min="0"
+                  />
+                </div>
               </div>
             </div>
-          </div>
 
-          <div className="flex space-x-2 pt-4">
-            <button
-              onClick={handleSave}
-              className="px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600"
-            >
-              저장
-            </button>
-            <button
-              onClick={handleDelete}
-              className="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600"
-            >
-              삭제
-            </button>
+            <div className={styles.buttonGroup}>
+              <button
+                onClick={handleSave}
+                className={styles.saveButton}
+              >
+                저장
+              </button>
+              <button
+                onClick={handleDelete}
+                className={styles.deleteButton}
+              >
+                삭제
+              </button>
+            </div>
           </div>
         </div>
       ) : (
-        <p>로딩 중...</p>
+        <p className={styles.loadingMessage}>로딩 중...</p>
       )}
     </div>
   );

--- a/src/pages/admin/AdminUserDetail.jsx
+++ b/src/pages/admin/AdminUserDetail.jsx
@@ -72,7 +72,6 @@ export default function AdminUserDetail() {
       if (err.response) {
         const errorMessage = err.response.data?.message || '알 수 없는 오류';
         
-        // 전화번호 형식 에러 메시지
         if (errorMessage.includes('phoneNumber') && errorMessage.includes('일치해야 합니다')) {
           alert('전화번호 형식이 올바르지 않습니다. 전화번호의 양식은 010-0000-0000 입니다.');
         } else {
@@ -130,14 +129,8 @@ export default function AdminUserDetail() {
       {user ? (
         <div className="space-y-4">
           <div>
-            <label className="block mb-1">아이디</label>
-            <input
-              type="text"
-              name="username"
-              value={form.username}
-              onChange={handleChange}
-              className="w-full border px-3 py-2 rounded"
-            />
+            <span className="font-medium block mb-1">아이디: </span> 
+            <span className="text-sm">{user.username}</span>
           </div>
           <div>
             <label className="block mb-1">이름</label>
@@ -187,10 +180,6 @@ export default function AdminUserDetail() {
           <div className="bg-gray-50 p-4 rounded">
             <h3 className="font-semibold mb-2">수치 정보</h3>
             <div className="grid grid-cols-2 gap-4">
-              <div>
-                <span className="font-medium block mb-1">ID:</span> 
-                <span className="text-sm">{user.id}</span>
-              </div>
               <div>
                 <span className="font-medium block mb-1">레벨:</span>
                 <span className="text-sm">{user.level}</span>

--- a/src/pages/admin/AdminUserDetail.module.scss
+++ b/src/pages/admin/AdminUserDetail.module.scss
@@ -1,0 +1,212 @@
+.AdminUserDetail {
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+  background-color: #f7f7fa;
+  min-height: 100vh;
+
+  .title {
+    font-size: 24px;
+    font-weight: bold;
+    margin-bottom: 20px;
+    color: #1e293b;
+  }
+
+  .content {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    max-width: 800px;
+  }
+
+  .card {
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.06);
+    padding: 20px;
+    border: 1px solid #e0e0e0;
+  }
+
+  .formGroup {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+
+  label {
+    font-size: 14px;
+    font-weight: 600;
+    color: #3b4252;
+    margin-bottom: 4px;
+  }
+
+  .readOnlyField {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 16px;
+  }
+
+  .readOnlyLabel {
+    font-size: 14px;
+    font-weight: 600;
+    color: #3b4252;
+  }
+
+  .readOnlyValue {
+    font-size: 14px;
+    color: #444;
+    padding: 8px 0;
+  }
+
+  input {
+    padding: 12px;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    font-size: 14px;
+    color: #333;
+    background-color: #fff;
+    transition: border-color 0.2s;
+    
+    &:focus {
+      outline: none;
+      border-color: #3b82f6;
+    }
+    
+    &::placeholder {
+      color: #6b7280;
+    }
+  }
+
+  textarea {
+    padding: 12px;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    font-size: 14px;
+    color: #333;
+    background-color: #fff;
+    resize: vertical;
+    min-height: 80px;
+    transition: border-color 0.2s;
+    
+    &:focus {
+      outline: none;
+      border-color: #3b82f6;
+    }
+  }
+
+  select {
+    padding: 12px;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    font-size: 14px;
+    color: #333;
+    background-color: #fff;
+    cursor: pointer;
+    transition: border-color 0.2s;
+    
+    &:focus {
+      outline: none;
+      border-color: #3b82f6;
+    }
+  }
+
+  .statsCard {
+    background: #f1f5f9;
+    border-radius: 12px;
+    padding: 20px;
+    margin-top: 20px;
+  }
+
+  .statsTitle {
+    font-size: 16px;
+    font-weight: 600;
+    color: #1e293b;
+    margin-bottom: 16px;
+  }
+
+  .statsGrid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 16px;
+  }
+
+  .statItem {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .statLabel {
+    font-size: 14px;
+    font-weight: 600;
+    color: #3b4252;
+  }
+
+  .statValue {
+    font-size: 14px;
+    color: #444;
+    padding: 4px 0;
+  }
+
+  .statInput {
+    padding: 8px;
+    border: 1px solid #e0e0e0;
+    border-radius: 6px;
+    font-size: 14px;
+    color: #333;
+    background-color: #fff;
+    transition: border-color 0.2s;
+    
+    &:focus {
+      outline: none;
+      border-color: #3b82f6;
+    }
+  }
+
+  .buttonContainer {
+    display: flex;
+    gap: 12px;
+    margin-top: 24px;
+    padding-top: 20px;
+    border-top: 1px solid #e0e0e0;
+  }
+
+  button {
+    padding: 12px 24px;
+    border: none;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s;
+    
+    &.saveButton {
+      background-color: #16a34a;
+      color: white;
+      
+      &:hover {
+        background-color: #15803d;
+      }
+    }
+    
+    &.deleteButton {
+      background-color: #dc2626;
+      color: white;
+      
+      &:hover {
+        background-color: #b91c1c;
+      }
+    }
+  }
+
+  .loadingMessage {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 200px;
+    font-size: 16px;
+    color: #6b7280;
+  }
+}

--- a/src/pages/admin/AdminUsersList.jsx
+++ b/src/pages/admin/AdminUsersList.jsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { getUsers }  from '../../api/adminService';
+import { getUsers } from '../../api/adminService';
 import UserTable from '../../components/Admin/UserTable';
+import styles from './AdminUsersList.module.scss';
 
 export default function AdminUsersList() {
   const [users, setUsers] = useState([]);
 
   useEffect(() => {
-    
     const fetchUsers = async () => {
       try {
         const res = await getUsers();
@@ -23,9 +23,13 @@ export default function AdminUsersList() {
   console.log('현재 users 상태:', users);
 
   return (
-    <div>
-      <h2 className="text-xl font-semibold mb-4">전체 회원</h2>
-      <UserTable users={users} />
+    <div className={styles.AdminUsersList}>
+      <h2 className={styles.title}>전체 회원</h2>
+      <div className={styles.content}>
+        <div className={styles.card}>
+          <UserTable users={users} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/pages/admin/AdminUsersList.module.scss
+++ b/src/pages/admin/AdminUsersList.module.scss
@@ -1,0 +1,221 @@
+.AdminUsersList {
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+  background-color: #f7f7fa;
+  min-height: 100vh;
+
+  .title {
+    font-size: 24px;
+    font-weight: bold;
+    margin-bottom: 20px;
+    color: #1e293b;
+  }
+
+  .content {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+  }
+
+  .card {
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.06);
+    padding: 20px;
+    border: 1px solid #e0e0e0;
+  }
+
+  .filterContainer {
+    display: flex;
+    gap: 12px;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+  }
+
+  .searchInput {
+    padding: 12px;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    font-size: 14px;
+    color: #333;
+    background-color: #fff;
+    min-width: 200px;
+    transition: border-color 0.2s;
+    
+    &:focus {
+      outline: none;
+      border-color: #3b82f6;
+    }
+    
+    &::placeholder {
+      color: #6b7280;
+    }
+  }
+
+  .filterButton {
+    padding: 12px 16px;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    background-color: #fff;
+    color: #333;
+    font-size: 14px;
+    cursor: pointer;
+    transition: all 0.2s;
+    
+    &:hover {
+      background-color: #f8fafc;
+      border-color: #3b82f6;
+    }
+    
+    &.active {
+      background-color: #3b82f6;
+      color: white;
+      border-color: #3b82f6;
+    }
+  }
+
+  .tableContainer {
+    overflow-x: auto;
+    border-radius: 8px;
+    border: 1px solid #e0e0e0;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 14px;
+    
+    th, td {
+      padding: 12px;
+      text-align: left;
+      border-bottom: 1px solid #e0e0e0;
+    }
+    
+    th {
+      background-color: #f8fafc;
+      color: #374151;
+      font-weight: 600;
+      font-size: 13px;
+      text-transform: uppercase;
+      letter-spacing: 0.025em;
+    }
+    
+    td {
+      color: #6b7280;
+      background-color: #fff;
+    }
+    
+    tr:hover {
+      background-color: #f9fafb;
+    }
+  }
+
+  .statusBadge {
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: 500;
+    
+    &.active {
+      background-color: #dcfce7;
+      color: #16a34a;
+    }
+    
+    &.inactive {
+      background-color: #fef2f2;
+      color: #dc2626;
+    }
+  }
+
+  .roleBadge {
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: 500;
+    
+    &.admin {
+      background-color: #fef3c7;
+      color: #d97706;
+    }
+    
+    &.lecturer {
+      background-color: #e0e7ff;
+      color: #6366f1;
+    }
+    
+    &.user {
+      background-color: #f3f4f6;
+      color: #6b7280;
+    }
+  }
+
+  .actionButton {
+    padding: 8px 12px;
+    border: none;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s;
+    margin-right: 8px;
+    
+    &.viewButton {
+      background-color: #3b82f6;
+      color: white;
+      
+      &:hover {
+        background-color: #2563eb;
+      }
+    }
+    
+    &.editButton {
+      background-color: #16a34a;
+      color: white;
+      
+      &:hover {
+        background-color: #15803d;
+      }
+    }
+    
+    &.deleteButton {
+      background-color: #dc2626;
+      color: white;
+      
+      &:hover {
+        background-color: #b91c1c;
+      }
+    }
+  }
+
+  .emptyState {
+    text-align: center;
+    padding: 40px;
+    color: #6b7280;
+    
+    .emptyIcon {
+      font-size: 48px;
+      margin-bottom: 16px;
+    }
+    
+    .emptyText {
+      font-size: 16px;
+      font-weight: 500;
+      margin-bottom: 8px;
+    }
+    
+    .emptySubtext {
+      font-size: 14px;
+      color: #9ca3af;
+    }
+  }
+
+  .loadingMessage {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 200px;
+    font-size: 16px;
+    color: #6b7280;
+  }
+}

--- a/src/pages/user/DashboardPage.jsx
+++ b/src/pages/user/DashboardPage.jsx
@@ -9,8 +9,6 @@ import DailyQuest from "../../components/Dashboard/DailyQuest";
 import AttendanceCheck from "../../components/Dashboard/AttendanceCheck";
 import UserProfile from "../../components/Dashboard/UserProfile";
 import RecentDiary from "../../components/Dashboard/RecentDiary";
-import BookmarkForm from "../../components/Dashboard/BookmarkForm";
-import BookmarkList from "../../components/Dashboard/BookmarkList";
 import useUserStore from "../../stores/userStore";
 import api from "../../api/axiosInstance";
 import useBreadcrumbStore from "../../stores/breadcrumbStore";

--- a/src/pages/user/DashboardPage.jsx
+++ b/src/pages/user/DashboardPage.jsx
@@ -13,6 +13,7 @@ import useUserStore from "../../stores/userStore";
 import api from "../../api/axiosInstance";
 import useBreadcrumbStore from "../../stores/breadcrumbStore";
 import BookmarkSection from "../../components/Dashboard/BookmarkSection";
+import AdminButton from "../../components/Admin/AdminButton"; 
 
 function DashboardPage() {
   const userInfo = useUserStore((state) => state.userInfo);
@@ -40,14 +41,9 @@ function DashboardPage() {
         name={userInfo.name}
         className={styles.dashboardGreeting}
       />
-      {userInfo.role === 'ADMIN' && (
-        <div className="flex justify-end mb-4">
-          <Link
-            to="/admin"
-            className="px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600"
-          >관리자 페이지</Link>
-        </div>
-      )}
+      
+      {userInfo.role === 'ADMIN' && <AdminButton />}
+      
       <DashboardMenu />
       <div> <BookmarkSection/></div>
       <div className={styles.dashboardContent}>


### PR DESCRIPTION
관리자 페이지 css 구현하였습니다.

<img width="4064" height="2334" alt="스크린샷 2025-07-14 오전 9 55 16" src="https://github.com/user-attachments/assets/c8f717ca-7ff8-40de-84f9-293eed676f54" />
<img width="4064" height="2334" alt="스크린샷 2025-07-14 오전 9 55 17" src="https://github.com/user-attachments/assets/951db432-ebd1-409a-a301-0c8da9dd4faf" />
<img width="4064" height="2334" alt="스크린샷 2025-07-14 오전 9 55 19" src="https://github.com/user-attachments/assets/44f355e6-55a6-4814-9e9b-40aac106a06c" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 관리자 페이지로 이동할 수 있는 AdminButton이 추가되었습니다.

* **Style**
  * 관리자 관련 페이지(관리자 레이아웃, 회원 목록, 회원 상세, 유저 테이블 등)의 스타일이 CSS 모듈을 활용한 일관된 디자인으로 개선되었습니다.
  * 기존 Tailwind 및 인라인 스타일이 CSS 모듈 기반 스타일로 대체되어 UI가 더욱 깔끔하고 현대적으로 변경되었습니다.

* **Refactor**
  * 관리자 레이아웃에 인증 및 권한 확인 로직이 추가되어, 비관리자 접근 시 대시보드로 리디렉션됩니다.
  * 관리자 상세 페이지에서 사용자 ID 필드가 읽기 전용으로 변경되었습니다.

* **Bug Fixes**
  * 없음

* **Chores**
  * 없음
<!-- end of auto-generated comment: release notes by coderabbit.ai -->